### PR TITLE
refactor: replace logrus with slog for consistent logging across the …

### DIFF
--- a/app/core/filesystem/filesystem.go
+++ b/app/core/filesystem/filesystem.go
@@ -20,8 +20,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"github.com/hydraide/hydraide/app/core/compressor"
-	log "github.com/sirupsen/logrus"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -336,7 +336,7 @@ func (fs *filesystem) GetFile(filePath string) ([][]byte, error) {
 	fileContent, err := io.ReadAll(file)
 	if err != nil {
 		if err := file.Close(); err != nil {
-			log.WithField("file", filePath).Error("Error closing file")
+			slog.Error("Error closing file after read failure", "file", filePath, "error", err.Error())
 		}
 		return nil, err
 	}
@@ -418,10 +418,7 @@ func (fs *filesystem) GetAllFileContents(folderPath string, excludedFiles ...str
 		if err != nil {
 			func() {
 				if closeErr := file.Close(); closeErr != nil {
-					log.WithFields(log.Fields{
-						"file":  filePath,
-						"error": closeErr,
-					}).Error("Error closing file after read failure")
+					slog.Error("Error closing file after read failure", "file", filePath, "error", closeErr.Error())
 				}
 			}()
 
@@ -519,10 +516,7 @@ func encodeBinaryLength(data []byte) []byte {
 	buf := new(bytes.Buffer)
 	// Write length in binary format
 	if err := binary.Write(buf, binary.LittleEndian, length); err != nil {
-		log.WithFields(log.Fields{
-			"error":       err,
-			"data_length": len(data),
-		}).Error("Failed to encode binary length")
+		slog.Error("Failed to encode binary length, returning nil", "error", err.Error(), "data_length", len(data))
 		return nil // Return nil if encoding fails
 	}
 	return buf.Bytes() // Return length bytes
@@ -549,10 +543,7 @@ func (fs *filesystem) deleteIfEmpty(folderPath string) error {
 	}
 	defer func() {
 		if closeErr := dir.Close(); closeErr != nil {
-			log.WithFields(log.Fields{
-				"folder": folderPath,
-				"error":  closeErr,
-			}).Error("Error closing directory after checking emptiness")
+			slog.Error("Error closing directory after checking emptiness", "folder", folderPath, "error", closeErr.Error())
 		}
 	}()
 

--- a/app/core/hydra/hydra_test.go
+++ b/app/core/hydra/hydra_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hydraide/hydraide/app/core/safeops"
 	"github.com/hydraide/hydraide/app/core/settings"
 	"github.com/hydraide/hydraide/app/name"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -202,10 +202,7 @@ func TestHydra_SummonSwamp(t *testing.T) {
 
 				swampInterface, err := hydraInterface.SummonSwamp(swampCtx, 10, name.New().Sanctuary(sanctuaryForQuickTest).Realm("test-words-to-domains").Swamp(workingWord))
 				if err != nil {
-					// amikor a hydra leáll, akkor a summon errort ad vissza
-					log.WithFields(log.Fields{
-						"error": err.Error(),
-					}).Error("error while summoning swamp")
+					slog.Error("error while summoning swamp", "error", err)
 					return
 				}
 

--- a/app/core/hydra/swamp/metadata/metadata.go
+++ b/app/core/hydra/swamp/metadata/metadata.go
@@ -13,7 +13,7 @@ package metadata
 import (
 	"encoding/gob"
 	"github.com/hydraide/hydraide/app/name"
-	log "github.com/sirupsen/logrus"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -110,9 +110,7 @@ func (m *metadata) SaveToFile() {
 		return
 	}
 	if err := m.save(); err != nil {
-		log.WithFields(log.Fields{
-			"error": err,
-		}).Error("failed to save metadata to file")
+		slog.Error("failed to save metadata to file", "error", err)
 	}
 }
 
@@ -205,18 +203,14 @@ func (m *metadata) load() {
 
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.WithFields(log.Fields{
-				"error": err,
-			}).Error("failed to close metadata file")
+			slog.Error("failed to close metadata file", "error", err)
 		}
 	}()
 
 	// Unmarshal the GOB encoded file into m.meta
 	decoder := gob.NewDecoder(file)
 	if err := decoder.Decode(&m.meta); err != nil {
-		log.WithFields(log.Fields{
-			"error": err,
-		}).Error("failed to decode metadata from GOB")
+		slog.Error("failed to decode metadata from GOB", "error", err)
 		m.meta = &Meta{KeyValuePairs: make(map[string]string)} // default
 	}
 }
@@ -229,27 +223,20 @@ func (m *metadata) save() error {
 	// IMPORTANT!! We do NOT create the folder structure here — it's the swamp's responsibility to create it.
 	file, err := os.Create(mFile)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"error":         err,
-			"metadata file": mFile,
-		}).Error("failed to create metadata file")
+		slog.Error("failed to create metadata file", "error", err, "metadata_file", mFile)
 		return err
 	}
 
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.WithFields(log.Fields{
-				"error": err,
-			}).Error("failed to close metadata file")
+			slog.Error("failed to close metadata file", "error", err)
 		}
 	}()
 
 	// gob encoder
 	encoder := gob.NewEncoder(file)
 	if err := encoder.Encode(m.meta); err != nil {
-		log.WithFields(log.Fields{
-			"error": err,
-		}).Error("failed to encode metadata to GOB")
+		slog.Error("failed to encode metadata to GOB", "error", err)
 		return err
 	}
 

--- a/app/core/hydra/swamp/swamp.go
+++ b/app/core/hydra/swamp/swamp.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hydraide/hydraide/app/core/hydra/swamp/treasure/guard"
 	"github.com/hydraide/hydraide/app/core/hydra/swamp/vigil"
 	"github.com/hydraide/hydraide/app/name"
-	log "github.com/sirupsen/logrus"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -2433,7 +2433,7 @@ func (s *swamp) buildBeacon(beaconASC beacon.Beacon, beaconDESC beacon.Beacon, b
 		}
 		if err != nil {
 			beaconASC.SetInitialized(false)
-			log.WithField("error", err).Error("failed to sort keyBeaconASC")
+			slog.Error("failed to sort keyBeaconASC", "error", err)
 		}
 	}
 
@@ -2477,7 +2477,7 @@ func (s *swamp) buildBeacon(beaconASC beacon.Beacon, beaconDESC beacon.Beacon, b
 		}
 		if err != nil {
 			beaconDESC.SetInitialized(false)
-			log.WithField("error", err).Error("failed to sort keyBeaconDESC")
+			slog.Error("failed to sort keyBeaconDESC", "error", err)
 		}
 	}
 
@@ -2492,12 +2492,12 @@ func (s *swamp) addToKeyBeacon(treasureInterface treasure.Treasure) {
 	s.keyBeaconASC.Add(treasureInterface)
 	err := s.keyBeaconASC.SortByKeyAsc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort keyBeaconASC")
+		slog.Error("failed to sort keyBeaconASC", "error", err)
 	}
 	s.keyBeaconDESC.Add(treasureInterface)
 	err = s.keyBeaconDESC.SortByKeyDesc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort keyBeaconDESC")
+		slog.Error("failed to sort keyBeaconDESC", "error", err)
 	}
 }
 
@@ -2512,12 +2512,12 @@ func (s *swamp) addToCreationTimeBeacon(treasureInterface treasure.Treasure) {
 	s.creationTimeBeaconASC.Add(treasureInterface)
 	err := s.creationTimeBeaconASC.SortByCreationTimeAsc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort creationTimeBeaconASC")
+		slog.Error("failed to sort creationTimeBeaconASC", "error", err)
 	}
 	s.creationTimeBeaconDESC.Add(treasureInterface)
 	err = s.creationTimeBeaconDESC.SortByCreationTimeDesc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort creationTimeBeaconDESC")
+		slog.Error("failed to sort creationTimeBeaconDESC", "error", err)
 	}
 }
 func (s *swamp) addToUpdateTimeBeacon(treasureInterface treasure.Treasure) {
@@ -2529,12 +2529,12 @@ func (s *swamp) addToUpdateTimeBeacon(treasureInterface treasure.Treasure) {
 	s.updateTimeBeaconASC.Add(treasureInterface)
 	err := s.updateTimeBeaconASC.SortByUpdateTimeAsc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort updateTimeBeaconASC")
+		slog.Error("failed to sort updateTimeBeaconASC", "error", err)
 	}
 	s.updateTimeBeaconDESC.Add(treasureInterface)
 	err = s.updateTimeBeaconDESC.SortByUpdateTimeDesc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort updateTimeBeaconDESC")
+		slog.Error("failed to sort updateTimeBeaconDESC", "error", err)
 	}
 
 }
@@ -2547,13 +2547,13 @@ func (s *swamp) addToExpirationTimeBeacon(treasureInterface treasure.Treasure) {
 	s.expirationTimeBeaconASC.Add(treasureInterface)
 	err := s.expirationTimeBeaconASC.SortByExpirationTimeAsc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort expirationTimeBeaconASC")
+		slog.Error("failed to sort expirationTimeBeaconASC", "error", err)
 	}
 
 	s.expirationTimeBeaconDESC.Add(treasureInterface)
 	err = s.expirationTimeBeaconDESC.SortByExpirationTimeDesc()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort expirationTimeBeaconDESC")
+		slog.Error("failed to sort expirationTimeBeaconDESC", "error", err)
 	}
 
 }
@@ -2566,12 +2566,12 @@ func (s *swamp) addToValueBeacon(treasureInterface treasure.Treasure) {
 	s.valueBeaconASC.Add(treasureInterface)
 	err := s.valueBeaconASC.SortByValueInt64ASC()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort valueIntBeaconASC")
+		slog.Error("failed to sort valueIntBeaconASC", "error", err)
 	}
 	s.valueBeaconDESC.Add(treasureInterface)
 	err = s.valueBeaconDESC.SortByValueInt64DESC()
 	if err != nil {
-		log.WithField("error", err).Error("failed to sort valueIntBeaconDESC")
+		slog.Error("failed to sort valueIntBeaconDESC", "error", err)
 	}
 }
 

--- a/app/core/zeus/zeus.go
+++ b/app/core/zeus/zeus.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hydraide/hydraide/app/core/hydra/lock"
 	"github.com/hydraide/hydraide/app/core/safeops"
 	"github.com/hydraide/hydraide/app/core/settings"
-	log "github.com/sirupsen/logrus"
+	"log/slog"
 	"os"
 )
 
@@ -82,7 +82,7 @@ func (z *zeus) GetHydra() hydra.Hydra {
 
 func (z *zeus) StartHydra() {
 
-	log.Info("Start summoning the Hydra...")
+	slog.Info("HydrAIDE DataEngine is starting...")
 
 	z.safeopsInterface = safeops.New()
 
@@ -90,7 +90,7 @@ func (z *zeus) StartHydra() {
 		for {
 			select {
 			case <-z.safeopsInterface.MonitorPanic():
-				log.Error("Zeus is stopping the hydra because there was a panic in the system")
+				slog.Error("Zeus is stopping the HydrAIDE because there was a panic in the system")
 				z.StopHydra()
 				return
 			}


### PR DESCRIPTION
This pull request replaces the `logrus` logging library with the `slog` library across multiple files in the codebase. The changes involve updating import statements and refactoring logging calls to align with the `slog` API, which uses structured key-value pairs for logging. Below is a summary of the most important changes grouped by theme:

### Logging Library Replacement
* Replaced `logrus` (`log`) with `slog` in the import statements of various files, including `filesystem.go`, `hydra.go`, `hydra_test.go`, and `chronicler.go`. (`[[1]](diffhunk://#diff-245bec125e22a062172b41625336c4e1d60676f963cc14777bbc2cf9401b2fd9L23-R24)`, `[[2]](diffhunk://#diff-cd79c0497d6cc256e478e8c8ab2adfc42c97587aa9bc05781200cfee5eb7b4f7L16-R16)`, `[[3]](diffhunk://#diff-d26eede8e9ee7b5736070dc4dbc5a7e00e3750f6c7b106903a64ddb474971fe4L13-R14)`, `[[4]](diffhunk://#diff-7ecf1228f2e19234b73155451c9cf44ab27d960390d4db982583373f56974372L17-R17)`)

### Refactoring Logging Calls
#### Filesystem Module
* Updated error logging in `GetFile`, `GetAllFileContents`, `encodeBinaryLength`, and `deleteIfEmpty` to use `slog.Error` with key-value pairs. (`[[1]](diffhunk://#diff-245bec125e22a062172b41625336c4e1d60676f963cc14777bbc2cf9401b2fd9L339-R339)`, `[[2]](diffhunk://#diff-245bec125e22a062172b41625336c4e1d60676f963cc14777bbc2cf9401b2fd9L421-R421)`, `[[3]](diffhunk://#diff-245bec125e22a062172b41625336c4e1d60676f963cc14777bbc2cf9401b2fd9L522-R519)`, `[[4]](diffhunk://#diff-245bec125e22a062172b41625336c4e1d60676f963cc14777bbc2cf9401b2fd9L552-R546)`)

#### Hydra Core
* Refactored logging in `SummonSwamp`, `GracefulStop`, and `eventCallbackFunction` to use `slog` methods like `slog.Warn` and `slog.Error` with structured logging. (`[[1]](diffhunk://#diff-cd79c0497d6cc256e478e8c8ab2adfc42c97587aa9bc05781200cfee5eb7b4f7L416-R416)`, `[[2]](diffhunk://#diff-cd79c0497d6cc256e478e8c8ab2adfc42c97587aa9bc05781200cfee5eb7b4f7L457-R455)`, `[[3]](diffhunk://#diff-cd79c0497d6cc256e478e8c8ab2adfc42c97587aa9bc05781200cfee5eb7b4f7L698-R713)`, `[[4]](diffhunk://#diff-cd79c0497d6cc256e478e8c8ab2adfc42c97587aa9bc05781200cfee5eb7b4f7L930-R942)`)

#### Chronicler Module
* Updated logging in methods like `CreateDirectoryIfNotExists`, `Destroy`, `Load`, and `writeModifiedTreasures` to use `slog.Error` for consistent structured logging. (`[[1]](diffhunk://#diff-7ecf1228f2e19234b73155451c9cf44ab27d960390d4db982583373f56974372L121-R121)`, `[[2]](diffhunk://#diff-7ecf1228f2e19234b73155451c9cf44ab27d960390d4db982583373f56974372L139-R143)`, `[[3]](diffhunk://#diff-7ecf1228f2e19234b73155451c9cf44ab27d960390d4db982583373f56974372L168-R162)`, `[[4]](diffhunk://#diff-7ecf1228f2e19234b73155451c9cf44ab27d960390d4db982583373f56974372L341-R331)`)

### Test Code Updates
* Replaced `logrus` logging in `hydra_test.go` with `slog` for consistency in test logging. (`[app/core/hydra/hydra_test.goL205-R205](diffhunk://#diff-d26eede8e9ee7b5736070dc4dbc5a7e00e3750f6c7b106903a64ddb474971fe4L205-R205)`)

These changes improve consistency in logging across the codebase and align with the structured logging approach provided by `slog`.…application

