### PR TITLE
Fix port configuration prompt to reflect non-Docker usage

### DIFF
--- a/app/hydraidectl/cmd/init.go
+++ b/app/hydraidectl/cmd/init.go
@@ -14,6 +14,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// validatePort validates that the provided port string is a valid integer between 1 and 65535
+func validatePort(portStr string) (string, error) {
+	if portStr == "" {
+		return "", fmt.Errorf("port cannot be empty")
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", fmt.Errorf("port must be a valid integer")
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535")
+	}
+	return portStr, nil
+}
+
 type CertConfig struct {
 	CN  string
 	DNS []string
@@ -44,7 +59,8 @@ var initCmd = &cobra.Command{
 
 		reader := bufio.NewReader(os.Stdin)
 
-		fmt.Println("🚀 Starting HydrAIDE install wizard...\n")
+		fmt.Println("🚀 Starting HydrAIDE install wizard...")
+		fmt.Println()
 
 		var cert CertConfig
 		var envCfg EnvConfig
@@ -104,13 +120,27 @@ var initCmd = &cobra.Command{
 		}
 
 		fmt.Println("\n🔌 Port Configuration")
-		fmt.Println("This is the external port on your host machine that will map to the HydrAIDE container.")
-		fmt.Println("Clients will use this port to communicate with the HydrAIDE server.")
-		fmt.Print("Which port should HydrAIDE listen on? (default: 4900): ")
-		envCfg.HydraidePort, _ = reader.ReadString('\n')
-		envCfg.HydraidePort = strings.TrimSpace(envCfg.HydraidePort)
-		if envCfg.HydraidePort == "" {
-			envCfg.HydraidePort = "4900"
+		fmt.Println("This is the port where the HydrAIDE binary server will listen for client connections.")
+		fmt.Println("Set the bind port for the HydrAIDE server instance.")
+		
+		// Port validation loop for main port
+		for {
+			fmt.Print("Which port should HydrAIDE listen on? (default: 4900): ")
+			portInput, _ := reader.ReadString('\n')
+			portInput = strings.TrimSpace(portInput)
+			
+			if portInput == "" {
+				envCfg.HydraidePort = "4900"
+				break
+			}
+			
+			if validPort, err := validatePort(portInput); err != nil {
+				fmt.Printf("❌ Invalid port: %v. Please try again.\n", err)
+				continue
+			} else {
+				envCfg.HydraidePort = validPort
+				break
+			}
 		}
 
 		fmt.Println("\n📁 Base Path for HydrAIDE")
@@ -255,13 +285,26 @@ var initCmd = &cobra.Command{
 		// HEALTH CHECK PORT
 		fmt.Println("\n❤️‍🩹 Health Check Endpoint")
 		fmt.Println("   Separate port for health checks and monitoring")
-		fmt.Print("Health check port [default: 4901]: ")
-		healthPort, _ := reader.ReadString('\n')
-		healthPort = strings.TrimSpace(healthPort)
-		if healthPort == "" {
-			healthPort = "4901"
+		
+		// Port validation loop for health check port
+		for {
+			fmt.Print("Health check port [default: 4901]: ")
+			healthPortInput, _ := reader.ReadString('\n')
+			healthPortInput = strings.TrimSpace(healthPortInput)
+			
+			if healthPortInput == "" {
+				envCfg.HealthCheckPort = "4901"
+				break
+			}
+			
+			if validPort, err := validatePort(healthPortInput); err != nil {
+				fmt.Printf("❌ Invalid port: %v. Please try again.\n", err)
+				continue
+			} else {
+				envCfg.HealthCheckPort = validPort
+				break
+			}
 		}
-		envCfg.HealthCheckPort = healthPort
 
 		// ======================
 		// CONFIGURATION SUMMARY

--- a/app/hydraidectl/cmd/init_test.go
+++ b/app/hydraidectl/cmd/init_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "valid port 4900",
+			input:    "4900",
+			expected: "4900",
+			hasError: false,
+		},
+		{
+			name:     "valid port 1",
+			input:    "1",
+			expected: "1",
+			hasError: false,
+		},
+		{
+			name:     "valid port 65535",
+			input:    "65535",
+			expected: "65535",
+			hasError: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "port 0 (invalid)",
+			input:    "0",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "port 65536 (invalid)",
+			input:    "65536",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "negative port",
+			input:    "-1",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "non-numeric input",
+			input:    "abc",
+			expected: "",
+			hasError: true,
+		},
+		{
+			name:     "port with spaces",
+			input:    " 4900 ",
+			expected: "",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := validatePort(tt.input)
+			
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("Expected error for input '%s', but got none", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error for input '%s', but got: %v", tt.input, err)
+				}
+				if result != tt.expected {
+					t.Errorf("Expected result '%s' for input '%s', but got '%s'", tt.expected, tt.input, result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes the misleading Docker references in the port configuration prompts of `hydraidectl init` command and adds proper port validation as requested in #69.

## Changes Made
- ✅ **Remove Docker references**: Updated port configuration prompts to reflect binary server usage instead of Docker containers
- ✅ **Add port validation**: Implemented strict validation for port range 1-65535 with clear error messages
- ✅ **Validation loops**: Added retry functionality for invalid port inputs on both main port and health check port  
- ✅ **Comprehensive tests**: Created unit tests covering valid/invalid port scenarios including edge cases
- ✅ **Maintain compatibility**: Preserved existing string storage behavior for internal port handling

## Test Results
```bash
=== RUN   TestValidatePort
=== RUN   TestValidatePort/valid_port_4900
=== RUN   TestValidatePort/valid_port_1  
=== RUN   TestValidatePort/valid_port_65535
=== RUN   TestValidatePort/empty_string
=== RUN   TestValidatePort/port_0_(invalid)
=== RUN   TestValidatePort/port_65536_(invalid)
=== RUN   TestValidatePort/negative_port
=== RUN   TestValidatePort/non-numeric_input
=== RUN   TestValidatePort/port_with_spaces
--- PASS: TestValidatePort (0.00s)
PASS
```

## Validation Examples
- ✅ Valid: `4900`, `1`, `65535` 
- ❌ Invalid: `0`, `65536`, `-1`, `abc`, ` 4900 `

## Before/After Comparison
**Before:**
```
🔌 Port Configuration
This is the external port on your host machine that will map to the HydrAIDE container.
Clients will use this port to communicate with the HydrAIDE server.
Which port should HydrAIDE listen on? (default: 4900): abc
[Accepts invalid input silently]
```

**After:**  
```
🔌 Port Configuration
This is the port where the HydrAIDE binary server will listen for client connections.
Set the bind port for the HydrAIDE server instance.
Which port should HydrAIDE listen on? (default: 4900): abc  
❌ Invalid port: port must be a valid integer. Please try again.
Which port should HydrAIDE listen on? (default: 4900): 4900
[Continues with valid input]
```

## Related Issues
- Closes #69 (Port configuration prompt improvement)
- Related to #51 (Parent issue for hydraidectl branching strategy)

🤖 Generated with [Claude Code](https://claude.ai/code)