### PR TITLE
Issue#74 validate health-check port

### DIFF
--- a/app/hydraidectl/cmd/init.go
+++ b/app/hydraidectl/cmd/init.go
@@ -253,15 +253,31 @@ var initCmd = &cobra.Command{
 		}
 
 		// HEALTH CHECK PORT
-		fmt.Println("\n❤️‍🩹 Health Check Endpoint")
-		fmt.Println("   Separate port for health checks and monitoring")
-		fmt.Print("Health check port [default: 4901]: ")
-		healthPort, _ := reader.ReadString('\n')
-		healthPort = strings.TrimSpace(healthPort)
-		if healthPort == "" {
-			healthPort = "4901"
+		for {
+			fmt.Println("\n❤️‍🩹 Health Check Endpoint")
+			fmt.Println("   Separate port for health checks and monitoring")
+			fmt.Print("Health check port [default: 4901]: ")
+			healthPort, _ := reader.ReadString('\n')
+			healthPort = strings.TrimSpace(healthPort)
+			if healthPort == "" {
+				healthPort = "4901"
+				envCfg.HealthCheckPort = healthPort
+				break
+			}
+			port, err := strconv.Atoi(healthPort)
+			if err != nil || port < 1 || port > 65535 {
+				fmt.Printf("\n❌ Invalid port %s. Please enter a valid port number between 1 and 65535.", healthPort)
+				continue
+			}
+
+			if healthPort == envCfg.HydraidePort {
+				fmt.Printf("\n⚠️  Port %s is already used by the main HydrAIDE server. Please choose a different one.", healthPort)
+				continue
+			}
+
+			envCfg.HealthCheckPort = healthPort
+			break
 		}
-		envCfg.HealthCheckPort = healthPort
 
 		// ======================
 		// CONFIGURATION SUMMARY


### PR DESCRIPTION
## 🧩 What does this PR do?

1. Validate that the health check port is a valid integer between 1 and 65535.
2. If the user provides invalid input (e.g. non-numeric, negative, out-of-range), show an error and prompt again.
3. Ensure that the health check port is not the same as the main server port specified earlier during init.
4. Set the default health check port to 4901 if the user input is empty.
5. Internally store the port value as a string, consistent with existing configuration behavior.

---

## 🔗 Related Issue(s)

Closes #74 

---


---

## 🗂️ Scope of Change
- [x] hydraidectl
