### PR TITLE
fix: add loglevel configuration validation for slog

### DIFF
--- a/app/hydraidectl/cmd/init.go
+++ b/app/hydraidectl/cmd/init.go
@@ -28,6 +28,20 @@ func validatePort(portStr string) (string, error) {
 	return portStr, nil
 }
 
+// validateLoglevel validates whether provided loglevel fits slog loglevels and returns a valid string
+func validateLoglevel(logLevel string) (string, error) {
+	logLevel = strings.ToLower(strings.TrimSpace(logLevel))
+	validLoglevels := map[string]bool{"debug": true, "info": true, "warn": true, "error": true}
+
+	if logLevel == "" {
+		return "info", nil
+	}
+	if validLoglevels[logLevel] {
+		return logLevel, nil
+	}
+	return "", fmt.Errorf("loglevel must be 'debug', 'info', 'warn' or 'error'")
+}
+
 type CertConfig struct {
 	CN  string
 	DNS []string
@@ -152,19 +166,26 @@ var initCmd = &cobra.Command{
 			envCfg.HydraideBasePath = "/mnt/hydraide"
 		}
 
-		fmt.Println("\n📝 Logging Configuration")
-
 		// LOG_LEVEL
-		fmt.Println("🔍 Log Level: Controls the amount of detail in system logs")
-		fmt.Println("   Options: trace, debug, info, warn, error, fatal, panic")
-		fmt.Println("   Recommended: 'info' for production, 'debug' for troubleshooting")
-		fmt.Print("Log level [default: info]: ")
-		logLevel, _ := reader.ReadString('\n')
-		logLevel = strings.TrimSpace(logLevel)
-		if logLevel == "" {
-			logLevel = "info"
+		fmt.Println("\n📝 Logging Configuration")
+		fmt.Println("   - Controls the verbosity of system logs.")
+		fmt.Println("   - Options: debug | info | warn | error")
+		fmt.Println("   - Default: info (recommended for production)")
+
+		// loglevel validation loop
+		for {
+			fmt.Print("Choose log level [default: info]: ")
+			logLevel, _ := reader.ReadString('\n')
+
+			logLevel, err := validateLoglevel(logLevel)
+			if err != nil {
+				fmt.Printf("\n ❌ Invalid loglevel: %v. Please try again.\n", err)
+				continue
+			}
+
+			envCfg.LogLevel = logLevel
+			break
 		}
-		envCfg.LogLevel = logLevel
 
 		// SYSTEM_RESOURCE_LOGGING
 		fmt.Println("\n💻 System Resource Monitoring")

--- a/app/hydraidectl/cmd/init_test.go
+++ b/app/hydraidectl/cmd/init_test.go
@@ -70,7 +70,7 @@ func TestValidatePort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := validatePort(tt.input)
-			
+
 			if tt.hasError {
 				if err == nil {
 					t.Errorf("Expected error for input '%s', but got none", tt.input)
@@ -82,6 +82,44 @@ func TestValidatePort(t *testing.T) {
 				if result != tt.expected {
 					t.Errorf("Expected result '%s' for input '%s', but got '%s'", tt.expected, tt.input, result)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateLoglevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		hasError bool
+	}{
+		{"Lowercase debug", "debug", "debug", false},
+		{"Lowercase info", "info", "info", false},
+		{"Lowercase warn", "warn", "warn", false},
+		{"Lowercase error", "error", "error", false},
+		{"Uppercase INFO", "INFO", "info", false},
+		{"Mixed casing", "DeBuG", "debug", false},
+		{"With spaces", "  warn  ", "warn", false},
+		{"Empty string", "", "info", false},
+		{"Weird casing", "dEbUg", "debug", false},
+		{"Newline wrapped", "\ninfo\n", "info", false},
+		{"Unsupported trace", "trace", "", true},
+		{"Unsupported string", "invalid level", "", true},
+		{"Special characters", "@debug", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := validateLoglevel(tt.input)
+			if tt.hasError && err == nil {
+				t.Errorf("Expected error for input '%s', but got none", tt.input)
+			}
+			if !tt.hasError && err != nil {
+				t.Errorf("Expected no error for input '%s', but got: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected result '%s' for input '%s', but got '%s'", tt.expected, tt.input, result)
 			}
 		})
 	}


### PR DESCRIPTION
## 🧩 What does this PR do?

This PR ensures users select only supported log levels (debug, info, warn, error) and defaults to info if no input is given.

---

## Example Prompt
  📝 Logging Configuration
  🔧 Log Level Configuration
     - Controls the verbosity of system logs.
     - Options: debug | info | warn | error
     - Default: info (recommended for production)
  Choose log level [default: info]: TRACE

  ❌ 'trace' is not a valid log level: loglevel must be one of: debug, info, warn, error
  Choose log level [default: info]: debug

---
## Test Result
`=== RUN   TestValidateLoglevel
=== RUN   TestValidateLoglevel/Lowercase_debug
--- PASS: TestValidateLoglevel/Lowercase_debug (0.00s)
=== RUN   TestValidateLoglevel/Lowercase_info
--- PASS: TestValidateLoglevel/Lowercase_info (0.00s)
=== RUN   TestValidateLoglevel/Lowercase_warn
--- PASS: TestValidateLoglevel/Lowercase_warn (0.00s)
=== RUN   TestValidateLoglevel/Lowercase_error
--- PASS: TestValidateLoglevel/Lowercase_error (0.00s)
=== RUN   TestValidateLoglevel/Uppercase_INFO
--- PASS: TestValidateLoglevel/Uppercase_INFO (0.00s)
=== RUN   TestValidateLoglevel/Mixed_casing
--- PASS: TestValidateLoglevel/Mixed_casing (0.00s)
=== RUN   TestValidateLoglevel/With_spaces
--- PASS: TestValidateLoglevel/With_spaces (0.00s)
=== RUN   TestValidateLoglevel/Empty_string
--- PASS: TestValidateLoglevel/Empty_string (0.00s)
=== RUN   TestValidateLoglevel/Weird_casing
--- PASS: TestValidateLoglevel/Weird_casing (0.00s)
=== RUN   TestValidateLoglevel/Newline_wrapped
--- PASS: TestValidateLoglevel/Newline_wrapped (0.00s)
=== RUN   TestValidateLoglevel/Unsupported_trace
--- PASS: TestValidateLoglevel/Unsupported_trace (0.00s)
=== RUN   TestValidateLoglevel/Unsupported_string
--- PASS: TestValidateLoglevel/Unsupported_string (0.00s)
=== RUN   TestValidateLoglevel/Special_characters
--- PASS: TestValidateLoglevel/Special_characters (0.00s)
--- PASS: TestValidateLoglevel (0.00s)
PASS
ok      github.com/hydraide/hydraide/app/hydraidectl/cmd    `

---
## Examples

- ✅ Valid: info, debug, Debug, waRN
- ❌ Invalid: 123, infooo, trace, fatal
---
## 🔗 Related Issue(s)
Closes #70 
Relates to #51 

---
