### PR TITLE
feat: enhance gRPC message size configuration with human-readable input

### DIFF
--- a/app/hydraidectl/cmd/init_test.go
+++ b/app/hydraidectl/cmd/init_test.go
@@ -240,6 +240,24 @@ func TestParseMessageSize(t *testing.T) {
 			expected: 10 * GB,
 			hasError: false,
 		},
+		{
+			name:     "multiple decimal points",
+			input:    "1.5.2GB",
+			expected: 0,
+			hasError: true,
+		},
+		{
+			name:     "floating point precision test",
+			input:    "1.999GB",
+			expected: 2146409906, // actual result from int64(1.999*GB + 0.5)
+			hasError: false,
+		},
+		{
+			name:     "decimal point without digits",
+			input:    ".5GB",
+			expected: 536870912, // int64(0.5*GB + 0.5)
+			hasError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

This PR enhances the gRPC message size configuration in HydrAIDE's CLI initialization wizard by implementing human-readable input parsing and improved validation with enhanced robustness based on code review feedback.

## Changes Made

### Core Functionality
- **Human-readable input support**: Users can now input message sizes in formats like `100MB`, `1GB`, `1.5GB`
- **Raw bytes support**: Still accepts raw byte values (e.g., `10485760`)
- **Case-insensitive units**: Supports both `MB`/`mb`, `GB`/gb, etc.
- **Range validation**: Enforces 10MB-10GB range with clear error messages
- **Default value change**: Changed default from 5GB to 10MB for better security

### Implementation Details
- `parseMessageSize()`: Parses human-readable input and converts to bytes with enhanced robustness
- `validateMessageSize()`: Validates size is within acceptable bounds (10MB-10GB)
- `formatSize()`: Converts bytes back to human-readable format for display
- Enhanced UI prompts with range information and recommendations

### Robustness Improvements (Based on Code Review)
- **Multiple decimal point validation**: Prevents invalid input like `1.5.2GB`
- **Efficient string building**: Uses `strings.Builder` for better performance
- **Floating-point precision**: Proper rounding with `+0.5` to avoid precision issues
- **Consistent error messages**: Unified format and clearer descriptions
- **Enhanced input parsing**: More robust handling of edge cases

### User Experience Improvements
- Clear validation error messages with suggested ranges
- Human-readable display in configuration summary
- Input validation loop prevents invalid configurations
- Support for decimal values (e.g., `1.5GB`) and leading decimals (e.g., `.5GB`)

## Test Coverage

Added comprehensive test suite covering:
- ✅ Valid inputs: raw bytes, unit suffixes, case insensitivity
- ✅ Invalid inputs: out of range values, unsupported units, malformed input
- ✅ Boundary conditions: exactly 10MB and 10GB limits
- ✅ Edge cases: empty input, negative values, zero values
- ✅ **New robustness tests**: multiple decimal points, floating-point precision, leading decimals

**Total Test Coverage**: 55+ test cases across 5 test functions

## Example Usage

```bash
# Before (raw bytes only)
Max message size [default: 5368709120]: 104857600

# After (human-readable with validation)
Max message size [default: 10.0MB]: 100MB
Max message size [default: 10.0MB]: 1.5GB
Max message size [default: 10.0MB]: .5GB    # Now supported
Max message size [default: 10.0MB]: 1.5.2GB # Properly rejected
❌ Invalid input: invalid format: multiple decimal points not allowed. Please try again.
```

## Security Impact

- **Reduced default**: Changed default from 5GB to 10MB reduces potential memory impact
- **Range enforcement**: Hard limits prevent excessive memory allocation
- **Input validation**: Prevents invalid configurations that could cause issues
- **Robust parsing**: Enhanced validation prevents malformed input exploitation

## Code Quality Improvements

### Performance Optimizations
- **Efficient string building**: `strings.Builder` instead of string concatenation
- **Optimized parsing**: Single-pass input validation
- **Minimal allocations**: Reduced memory overhead during parsing

### Robustness Enhancements
- **Input validation**: Multiple decimal point detection
- **Floating-point precision**: Proper rounding to avoid precision errors
- **Error consistency**: Unified error message format across all validation functions
- **Edge case handling**: Support for `.5GB` format and comprehensive boundary testing

## Testing

All tests pass with enhanced coverage:
```bash
go test ./app/hydraidectl/cmd/ -v
# 5 test functions with 55+ individual test cases
# PASS: TestValidatePort, TestValidateLoglevel, TestParseMessageSize, TestValidateMessageSize, TestFormatSize
# New: Multiple decimal points, floating-point precision, leading decimal tests
```

## Commits

1. **Initial Implementation** (`3e4dd77`): Core gRPC message size enhancement functionality
2. **Robustness Improvements** (`4fbbb28`): Code review feedback implementation with enhanced parsing and validation

## Related Issue

Closes #71

## Breaking Changes

⚠️ **Default Value Change**: The default gRPC message size has been changed from 5GB to 10MB for security reasons. Users relying on the large default should explicitly configure their desired size.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>