### PR TITLE
Feat/instance runner

### DIFF
--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
@@ -3,9 +3,7 @@ package instancerunner
 import (
 	"context"
 	"fmt"
-	"io"
-	"log"
-	"os"
+	"log/slog"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -14,17 +12,25 @@ import (
 	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner/locker"
 )
 
-// logger is the package's logger. By default, it is a silent logger that discards all output.
+// NoOpHandler is an slog.Handler that discards all log records.
+type NoOpHandler struct{}
+
+func (h *NoOpHandler) Enabled(_ context.Context, _ slog.Level) bool  { return false }
+func (h *NoOpHandler) Handle(_ context.Context, _ slog.Record) error { return nil }
+func (h *NoOpHandler) WithAttrs(_ []slog.Attr) slog.Handler          { return h }
+func (h *NoOpHandler) WithGroup(_ string) slog.Handler               { return h }
+
+// logger is the package's structured logger. By default, it is a silent logger that discards all output.
 // A custom logger can be set using the SetLogger function.
-var logger *log.Logger
+var logger *slog.Logger
 
 func init() {
 	// By default instance runner is silent. Logs are discarded.
-	logger = log.New(io.Discard, "", 0)
+	logger = slog.New(&NoOpHandler{})
 }
 
-// SetupLogger allows a client to provide a custom logger for verbose output.
-func SetupLogger(customLogger *log.Logger) {
+// SetupLogger allows a client to provide a custom structured logger for verbose output.
+func SetupLogger(customLogger *slog.Logger) {
 	logger = customLogger
 }
 
@@ -47,11 +53,17 @@ type InstanceController interface {
 }
 
 // systemdController implements InstanceController for Linux systems.
-type systemdController struct{}
+type systemdController struct {
+	timeout                 time.Duration
+	gracefulShutdownTimeout time.Duration
+}
 
 // StartInstance starts a systemd user service.
 // This function acquires a file-based lock to ensure exclusive access to the instance.
 func (c *systemdController) StartInstance(ctx context.Context, instance string) error {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
 	service := fmt.Sprintf("hydraserver-%s.service", instance)
 
 	// Pre-flight check: ensure the service file exists before attempting to start it.
@@ -65,45 +77,53 @@ func (c *systemdController) StartInstance(ctx context.Context, instance string) 
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
+		logger.Error("Failed to get Instance Locker")
 		return err
 	}
 	if err := locker.Lock(); err != nil {
 		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
 	}
+	logger.Debug("Locked instance", "instance_name", instance)
 	// Use defer to ensure the lock is always released when the function exits.
 	defer locker.Unlock()
-	return c.startInstanceOpe(ctx, service)
+	return c.startInstanceOp(ctx, service)
 }
 
 // startInstanceOpe is the core logic for starting an instance, lock is held.
-func (c *systemdController) startInstanceOpe(ctx context.Context, service string) error {
+func (c *systemdController) startInstanceOp(ctx context.Context, service string) error {
 
-	// Get the required environment variables for the user session
-	env, err := c.getUserSystemdEnv()
-	if err != nil {
-		return fmt.Errorf("failed to get user systemd environment: %w", err)
+	isEnabledCmd := exec.CommandContext(ctx, "systemctl", "is-enabled", "--quiet", service)
+	if err := isEnabledCmd.Run(); err != nil {
+		// If the service is not enabled, we enable it.
+		logger.Info("Enable Service", "service_name", service)
+		enableCmd := exec.CommandContext(ctx, "systemctl", "enable", service)
+		if err := enableCmd.Run(); err != nil {
+			return fmt.Errorf("failed to enable service '%s': %w", service, err)
+		}
 	}
 
-	cmd := exec.CommandContext(ctx, "systemctl", "--user", "start", service)
-	cmd.Env = env
+	cmd := exec.CommandContext(ctx, "systemctl", "start", service)
 
-	logger.Printf("Attempting to start service '%s'", service)
+	logger.Info("Attempting to start service", "service_name", service)
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
-		logger.Printf("failed to start service '%s'", service)
+		logger.Info("failed to start service", "service_name", service)
 		return fmt.Errorf("failed to start service '%s': %w", service, err)
 	}
 
-	logger.Printf("Successfully started service '%s'", service)
+	logger.Info("Successfully started service", "service_name", service)
 	return nil
 }
 
 // StopInstance stops a systemd user service gracefully.
 // This function acquires a file-based lock to ensure exclusive access to the instance.
 func (c *systemdController) StopInstance(ctx context.Context, instance string) error {
-	service := fmt.Sprintf("hydraserver-%s.service", instance)
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 
+	service := fmt.Sprintf("hydraserver-%s.service", instance)
+	logger.Debug("Stop Instance")
 	// Pre-flight check: ensure the service file exists.
 	exists, err := c.checkServiceExists(service)
 	if err != nil {
@@ -115,40 +135,36 @@ func (c *systemdController) StopInstance(ctx context.Context, instance string) e
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
+		logger.Error("Failed to get instance locker")
 		return err
 	}
 	if err := locker.Lock(); err != nil {
 		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
 	}
+	logger.Debug("File lock instance", "instance_name", instance)
 	// Use defer to ensure the lock is always released when the function exits.
 	defer locker.Unlock()
 
-	return c.stopInstanceOpe(ctx, service)
+	return c.stopInstanceOp(ctx, service)
 }
 
 // stopInstanceOpe is the core logic for stopping an instance, lock is held.
-func (c *systemdController) stopInstanceOpe(ctx context.Context, service string) error {
+func (c *systemdController) stopInstanceOp(ctx context.Context, service string) error {
 
 	// Check if the service is already inactive.
 	isActive, err := c.isServiceActive(service)
 	if err != nil {
-		logger.Printf("Failed to check status of '%s'", service)
+		logger.Info("Failed to check status of", "service_name", service)
 		return fmt.Errorf("failed to check status of '%s': %w", service, err)
 	}
 	if !isActive {
-		logger.Printf("Service '%s' is already stopped. No action needed.", service)
+		logger.Info("Service is already stopped. No action needed.", "service_name", service)
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, "systemctl", "--user", "stop", service)
+	cmd := exec.CommandContext(ctx, "systemctl", "stop", service)
 
-	env, err := c.getUserSystemdEnv()
-	if err != nil {
-		return fmt.Errorf("failed to get user systemd environment: %w", err)
-	}
-	cmd.Env = env
-
-	logger.Printf("Attempting to stop service '%s'", service)
+	logger.Info("Attempting to stop service", "service_name", service)
 
 	// Issue the stop command. The command itself doesn't wait for shutdown.
 	if err := cmd.Run(); err != nil {
@@ -156,12 +172,11 @@ func (c *systemdController) stopInstanceOpe(ctx context.Context, service string)
 	}
 
 	// Poll the service status to ensure it has fully shut down.
-	logger.Printf("Waiting for service '%s' to be fully stopped...", service)
+	logger.Info("Waiting for service to be fully stopped...", "service_name", service)
 
-	// Default to a 5-second timeout for graceful shutdown.
-	// Todo: Configurable timeout
 	pollingCtx, pollingCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer pollingCancel()
+	logger.Debug("Created polling with timeout context to check service status")
 
 	ticker := time.NewTicker(200 * time.Millisecond) // Poll every 200ms
 	defer ticker.Stop()
@@ -176,7 +191,7 @@ func (c *systemdController) stopInstanceOpe(ctx context.Context, service string)
 				return fmt.Errorf("failed to check service status during graceful stop: %w", checkErr)
 			}
 			if !isActive {
-				logger.Printf("Service '%s' is confirmed stopped.", service)
+				logger.Info("Service is confirmed stopped.", "service_name", service)
 				return nil
 			}
 		}
@@ -185,7 +200,10 @@ func (c *systemdController) stopInstanceOpe(ctx context.Context, service string)
 
 // RestartInstance stops and then starts a systemd user service instance.
 func (c *systemdController) RestartInstance(ctx context.Context, instanceName string) error {
-	logger.Printf("Attempting to restart instance '%s'...", instanceName)
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	logger.Info("Attempting to restart instance", "instance_name", instanceName)
 
 	service := fmt.Sprintf("hydraserver-%s.service", instanceName)
 
@@ -201,6 +219,7 @@ func (c *systemdController) RestartInstance(ctx context.Context, instanceName st
 	// Acquire the lock for the entire restart operation.
 	locker, err := locker.NewLocker(instanceName)
 	if err != nil {
+		logger.Error("Failed to get instance locker")
 		return err
 	}
 	if err := locker.Lock(); err != nil {
@@ -208,62 +227,34 @@ func (c *systemdController) RestartInstance(ctx context.Context, instanceName st
 	}
 	defer locker.Unlock()
 
+	logger.Info("Performing restart of the instance", "instance_name", instanceName)
 	// Stop the service gracefully.
-	if err := c.stopInstanceOpe(ctx, service); err != nil {
+	logger.Debug("Stop Instance", "instance_name", instanceName)
+	if err := c.stopInstanceOp(ctx, service); err != nil {
 		return fmt.Errorf("failed to gracefully stop instance '%s' for restart: %w", instanceName, err)
 	}
 
 	// Start the service.
-	if err := c.startInstanceOpe(ctx, service); err != nil {
+	logger.Debug("Start Instance", "instance_name", instanceName)
+	if err := c.startInstanceOp(ctx, service); err != nil {
 		return fmt.Errorf("failed to start instance '%s' after stop: %w", instanceName, err)
 	}
 
-	logger.Printf("Successfully restarted instance '%s'.", instanceName)
+	logger.Info("Successfully restarted instance", "instance_name", instanceName)
 	return nil
-}
-
-// getUserSystemdEnv retrieves the necessary environment variables for a systemd user session.
-func (c *systemdController) getUserSystemdEnv() ([]string, error) {
-	cmd := exec.Command("systemctl", "--user", "show-environment")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run 'systemctl --user show-environment': %w", err)
-	}
-
-	envMap := make(map[string]string)
-	for _, line := range strings.Split(string(output), "\n") {
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
-		}
-	}
-
-	// Build the final environment slice
-	var finalEnv []string
-	finalEnv = append(finalEnv, os.Environ()...) // Start with the existing environment
-	if dbusAddress, ok := envMap["DBUS_SESSION_BUS_ADDRESS"]; ok {
-		finalEnv = append(finalEnv, "DBUS_SESSION_BUS_ADDRESS="+dbusAddress)
-	}
-	if xdgRuntimeDir, ok := envMap["XDG_RUNTIME_DIR"]; ok {
-		finalEnv = append(finalEnv, "XDG_RUNTIME_DIR="+xdgRuntimeDir)
-	} else {
-		// Fallback for XDG_RUNTIME_DIR if not found, though unlikely
-		finalEnv = append(finalEnv, fmt.Sprintf("XDG_RUNTIME_DIR=/run/user/%d", os.Getuid()))
-	}
-
-	return finalEnv, nil
 }
 
 // checkServiceExists checks if a service file exists.
 func (c *systemdController) checkServiceExists(serviceName string) (bool, error) {
-	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+	logger.Debug("Check service exists..")
+	cmd := exec.Command("systemctl", "is-active", "--quiet", serviceName)
 	err := cmd.Run()
 	if err == nil {
 		// Service is active, exists.
 		return true, nil
 	}
 	if exitError, ok := err.(*exec.ExitError); ok {
-		// Exit code 4 means the service unit does not exist.
+		// Exit code 4 means the service does not exist.
 		if exitError.ExitCode() == 4 {
 			return false, nil
 		}
@@ -275,23 +266,29 @@ func (c *systemdController) checkServiceExists(serviceName string) (bool, error)
 
 // isServiceActive checks if a service is currently active.
 func (c *systemdController) isServiceActive(serviceName string) (bool, error) {
-	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+	logger.Debug("Check service active", "service_name", serviceName)
+	cmd := exec.Command("systemctl", "is-active", "--quiet", serviceName)
 	err := cmd.Run()
 	if err == nil {
+		logger.Debug("Service is active!")
 		return true, nil
 	}
 	if exitError, ok := err.(*exec.ExitError); ok {
 		// Inactive service or unknown
 		if exitError.ExitCode() == 3 || exitError.ExitCode() == 4 {
+			logger.Debug("Service is inactive")
 			return false, nil
 		}
 	}
+	logger.Debug("Service is inactive")
 	return false, err
 }
 
 // windowsController implements InstanceController for Windows via NSSM.
 type windowsController struct {
-	useNssm bool
+	useNssm                 bool
+	timeout                 time.Duration
+	gracefulShutdownTimeout time.Duration
 }
 
 // StartInstance installs (if needed) and starts an NSSM-wrapped service.
@@ -299,6 +296,9 @@ type windowsController struct {
 // It acquires the same file-based lock, then checks for existence via `nssm status`.
 // If missing, returns an error. Otherwise it calls `nssm start`.
 func (c *windowsController) StartInstance(ctx context.Context, instance string) error {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
 	service := fmt.Sprintf("hydraserver-%s", instance)
 
 	// Check if the service exists before attempting to start.
@@ -324,7 +324,7 @@ func (c *windowsController) StartInstance(ctx context.Context, instance string) 
 }
 
 func (c *windowsController) startInstanceOp(ctx context.Context, service string) error {
-	logger.Printf("[windows] Attempting to start service '%s'", service)
+	logger.Info("[windows] Attempting to start service", "service_name", service)
 	var cmd *exec.Cmd
 	if c.useNssm {
 		cmd = exec.CommandContext(ctx, "nssm", "start", service)
@@ -337,12 +337,15 @@ func (c *windowsController) startInstanceOp(ctx context.Context, service string)
 		return fmt.Errorf("failed to start service '%s': %w", service, err)
 	}
 
-	logger.Printf("[windows] Successfully started service '%s'", service)
+	logger.Info("[windows] Successfully started service", "service_name", service)
 	return nil
 }
 
 // StopInstance stops an NSSM service and then polls until it’s confirmed stopped.
 func (c *windowsController) StopInstance(ctx context.Context, instance string) error {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
 	service := fmt.Sprintf("hydraserver-%s", instance)
 
 	exists, err := c.checkServiceExists(ctx, service)
@@ -372,18 +375,18 @@ func (c *windowsController) stopInstanceOp(ctx context.Context, service string) 
 		return fmt.Errorf("status check failed for '%s': %w", service, err)
 	}
 	if !running {
-		logger.Printf("[windows] Service '%s' already stopped", service)
+		logger.Info("[windows] Service already stopped", "service_name", service)
 		return nil
 	}
 
-	logger.Printf("[windows] Stopping NSSM service '%s'", service)
+	logger.Info("[windows] Stopping NSSM service", "service_name", service)
 	cmd := exec.CommandContext(ctx, "nssm", "stop", service)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("nssm stop failed: %v\n%s", err, out)
 	}
 
 	// Poll until stopped or timeout
-	timeout := 5 * time.Second
+	timeout := c.gracefulShutdownTimeout
 	pollCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -400,7 +403,7 @@ func (c *windowsController) stopInstanceOp(ctx context.Context, service string) 
 				return fmt.Errorf("status check failed during stop poll: %w", err)
 			}
 			if !running {
-				logger.Printf("[windows] Service '%s' confirmed stopped", service)
+				logger.Info("[windows] Service confirmed stopped", "service_name", service)
 				return nil
 			}
 		}
@@ -409,7 +412,10 @@ func (c *windowsController) stopInstanceOp(ctx context.Context, service string) 
 
 // RestartInstance simply chains StopInstance then StartInstance under one lock.
 func (c *windowsController) RestartInstance(ctx context.Context, instance string) error {
-	logger.Printf("[windows] Restarting instance '%s'", instance)
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	logger.Info("[windows] Restarting instance", "instance_name", instance)
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
@@ -427,7 +433,7 @@ func (c *windowsController) RestartInstance(ctx context.Context, instance string
 	if err := c.startInstanceOp(ctx, service); err != nil {
 		return fmt.Errorf("failed to start after stop: %w", err)
 	}
-	logger.Printf("[windows] Successfully restarted '%s'", instance)
+	logger.Info("[windows] Successfully restarted", "service_name", instance)
 	return nil
 }
 
@@ -485,19 +491,43 @@ func checkNssmExists() bool {
 
 // NewInstanceController returns the appropriate controller based on the OS.
 // Currently, it supports "linux" and "windows". For any other OS, it returns nil.
-func NewInstanceController() InstanceController {
+// Take timeout in seconds to time out start/stop/restart operations.
+func NewInstanceController(options ...Option) InstanceController {
+
+	// timeout defaults to 5 seconds
+	cfg := &opts{timeout: 10 * time.Second, shutdownTimout: 5 * time.Second}
+	for _, option := range options {
+		option(cfg)
+	}
+
 	switch runtime.GOOS {
 	case "windows":
 		useNssm := checkNssmExists()
 		if useNssm {
-			logger.Println("NSSM found. Using NSSM for Windows service management.")
+			logger.Info("NSSM found. Using NSSM for Windows service management.")
 		} else {
-			logger.Println("NSSM not found. Falling back to PowerShell for Windows service management.")
+			logger.Info("NSSM not found. Falling back to PowerShell for Windows service management.")
 		}
-		return &windowsController{useNssm: useNssm}
+		return &windowsController{useNssm: useNssm, timeout: cfg.timeout, gracefulShutdownTimeout: cfg.shutdownTimout}
 	case "linux":
-		return &systemdController{}
+		return &systemdController{timeout: cfg.timeout, gracefulShutdownTimeout: cfg.shutdownTimout}
 	default:
 		return nil
 	}
+}
+
+// Option will help set configurations for instance runner
+type Option func(*opts)
+type opts struct {
+	timeout        time.Duration
+	shutdownTimout time.Duration
+}
+
+// WithStopTimeout takes timeout duration and sets it to instanceController
+func WithTimeout(d time.Duration) Option {
+	return func(o *opts) { o.timeout = d }
+}
+
+func WithGracefulShutdownTimeout(d time.Duration) Option {
+	return func(o *opts) { o.shutdownTimout = d }
 }

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
@@ -1,0 +1,205 @@
+package instancerunner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// InstanceController defines basic control operations for a HydrAIDE instance.
+type InstanceController interface {
+	StartInstance(ctx context.Context, instanceName string) error
+	StopInstance(ctx context.Context, instanceName string) error
+	RestartInstance(ctx context.Context, instanceName string) error
+}
+
+// systemdController implements InstanceController for Linux.
+type systemdController struct{}
+
+// StartInstance starts a systemd user service.
+func (c *systemdController) StartInstance(ctx context.Context, instance string) error {
+	service := fmt.Sprintf("hydraserver-%s.service", instance)
+
+	// Get the required environment variables for the user session
+	env, err := c.getUserSystemdEnv()
+	if err != nil {
+		return fmt.Errorf("failed to get user systemd environment: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "systemctl", "--user", "start", service)
+	cmd.Env = env
+
+	fmt.Printf("Starting service '%s' with command: %s %s\n", service, cmd.Path, strings.Join(cmd.Args, " "))
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to start service '%s': %w", service, err)
+	}
+
+	log.Printf("Successfully started service '%s'\n", service)
+	return nil
+}
+
+// StopInstance stops a systemd user service.
+func (c *systemdController) StopInstance(ctx context.Context, instance string) error {
+	service := fmt.Sprintf("hydraserver-%s.service", instance)
+
+	cmd := exec.CommandContext(ctx, "systemctl", "--user", "stop", service)
+
+	env, err := c.getUserSystemdEnv()
+	if err != nil {
+		return fmt.Errorf("failed to get user systemd environment: %w", err)
+	}
+	cmd.Env = env
+
+	fmt.Printf("Stopping service '%s' with command: %s %s\n", service, cmd.Path, strings.Join(cmd.Args, " "))
+
+	err = cmd.Run()
+	if err != nil {
+		// Check if the service is actually still active.
+		isActive, checkErr := c.isServiceActive(service)
+		if checkErr != nil {
+			return fmt.Errorf("failed to check service status after stop attempt: %w", checkErr)
+		}
+		if isActive {
+			return fmt.Errorf("failed to stop service '%s': %w", service, err)
+		}
+		// If it's not active, we can consider the stop successful, even if cmd.Run() returned an error.
+		log.Printf("Service '%s' was already stopped. Stop operation considered successful.", service)
+	} else {
+		log.Printf("Successfully stopped service '%s'\n", service)
+	}
+
+	return nil
+}
+
+// RestartInstance stops and then starts a systemd user service instance.
+func (c *systemdController) RestartInstance(ctx context.Context, instanceName string) error {
+	log.Printf("Attempting to restart instance '%s'...", instanceName)
+
+	// Stop the service.
+	log.Printf("Stopping service for instance '%s'...", instanceName)
+	err := c.StopInstance(ctx, instanceName)
+	if err != nil {
+		return fmt.Errorf("failed to stop instance '%s' for restart: %w", instanceName, err)
+	}
+
+	// Wait till the service is shut down completely.
+	log.Printf("Waiting for service '%s' to be fully stopped...", instanceName)
+	pollingCtx, pollingCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer pollingCancel()
+
+	// Check the service status until it's inactive.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+loop:
+	for {
+		select {
+		case <-pollingCtx.Done():
+			return fmt.Errorf("service '%s' did not stop in time for restart", instanceName)
+		case <-ticker.C:
+			isActive, err := c.isServiceActive(instanceName)
+			if err != nil {
+				return fmt.Errorf("failed to check status of '%s' during restart: %w", instanceName, err)
+			}
+			if !isActive {
+				log.Printf("Service '%s' is confirmed stopped.", instanceName)
+				break loop
+			}
+		}
+	}
+
+	// Start the service.
+	log.Printf("Starting service for instance '%s'...", instanceName)
+	err = c.StartInstance(ctx, instanceName)
+	if err != nil {
+		return fmt.Errorf("failed to start instance '%s' after stop: %w", instanceName, err)
+	}
+
+	log.Printf("Successfully restarted instance '%s'.", instanceName)
+	return nil
+}
+
+// getUserSystemdEnv retrieves the necessary environment variables for a systemd user session.
+func (c *systemdController) getUserSystemdEnv() ([]string, error) {
+	cmd := exec.Command("systemctl", "--user", "show-environment")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run 'systemctl --user show-environment': %w", err)
+	}
+
+	envMap := make(map[string]string)
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	// Build the final environment slice
+	var finalEnv []string
+	finalEnv = append(finalEnv, os.Environ()...) // Start with the existing environment
+	if dbusAddress, ok := envMap["DBUS_SESSION_BUS_ADDRESS"]; ok {
+		finalEnv = append(finalEnv, "DBUS_SESSION_BUS_ADDRESS="+dbusAddress)
+	}
+	if xdgRuntimeDir, ok := envMap["XDG_RUNTIME_DIR"]; ok {
+		finalEnv = append(finalEnv, "XDG_RUNTIME_DIR="+xdgRuntimeDir)
+	} else {
+		// Fallback for XDG_RUNTIME_DIR if not found, though unlikely
+		finalEnv = append(finalEnv, fmt.Sprintf("XDG_RUNTIME_DIR=/run/user/%d", os.Getuid()))
+	}
+
+	return finalEnv, nil
+}
+
+// Helper function to check service status
+func (c *systemdController) isServiceActive(serviceName string) (bool, error) {
+	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		// Inactive service or unknown
+		if exitError.ExitCode() == 3 || exitError.ExitCode() == 4 {
+			return false, nil
+		}
+	}
+	return false, err
+}
+
+// windowsController implements InstanceController for Windows using PowerShell.
+type windowsController struct{}
+
+func (c *windowsController) StartInstance(ctx context.Context, instance string) error {
+	service := fmt.Sprintf("hydraserver-%s", instance)
+	cmd := exec.Command("powershell", "Start-Service", service)
+	return cmd.Run()
+}
+
+func (c *windowsController) StopInstance(ctx context.Context, instance string) error {
+	service := fmt.Sprintf("hydraserver-%s", instance)
+	cmd := exec.Command("powershell", "Stop-Service", service)
+	return cmd.Run()
+}
+
+func (c *windowsController) RestartInstance(ctx context.Context, instance string) error {
+	return nil
+}
+
+// NewInstanceController returns the appropriate controller based on the OS.
+func NewInstanceController() InstanceController {
+	switch runtime.GOOS {
+	case "windows":
+		return &windowsController{}
+	case "linux":
+		return &systemdController{}
+	default:
+		return nil
+	}
+}

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
@@ -25,6 +25,15 @@ type systemdController struct{}
 func (c *systemdController) StartInstance(ctx context.Context, instance string) error {
 	service := fmt.Sprintf("hydraserver-%s.service", instance)
 
+	// Pre-flight check: ensure the service file exists before attempting to start it.
+	exists, err := c.checkServiceExists(service)
+	if err != nil {
+		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+	}
+	if !exists {
+		return fmt.Errorf("service '%s' not found", service)
+	}
+
 	// Get the required environment variables for the user session
 	env, err := c.getUserSystemdEnv()
 	if err != nil {
@@ -34,20 +43,41 @@ func (c *systemdController) StartInstance(ctx context.Context, instance string) 
 	cmd := exec.CommandContext(ctx, "systemctl", "--user", "start", service)
 	cmd.Env = env
 
-	fmt.Printf("Starting service '%s' with command: %s %s\n", service, cmd.Path, strings.Join(cmd.Args, " "))
+	log.Printf("Attempting to start service '%s'", service)
 
 	err = cmd.Run()
 	if err != nil {
+		log.Printf("failed to start service '%s'", service)
 		return fmt.Errorf("failed to start service '%s': %w", service, err)
 	}
 
-	log.Printf("Successfully started service '%s'\n", service)
+	log.Printf("Successfully started service '%s'", service)
 	return nil
 }
 
-// StopInstance stops a systemd user service.
+// StopInstance stops a systemd user service and waits for it to shut down gracefully.
 func (c *systemdController) StopInstance(ctx context.Context, instance string) error {
 	service := fmt.Sprintf("hydraserver-%s.service", instance)
+
+	// Pre-flight check: ensure the service file exists.
+	exists, err := c.checkServiceExists(service)
+	if err != nil {
+		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+	}
+	if !exists {
+		return fmt.Errorf("service '%s' not found", service)
+	}
+
+	// Check if the service is already inactive.
+	isActive, err := c.isServiceActive(service)
+	if err != nil {
+		log.Printf("Failed to check status of '%s'", service)
+		return fmt.Errorf("failed to check status of '%s': %w", service, err)
+	}
+	if !isActive {
+		log.Printf("Service '%s' is already stopped. No action needed.", service)
+		return nil
+	}
 
 	cmd := exec.CommandContext(ctx, "systemctl", "--user", "stop", service)
 
@@ -57,67 +87,52 @@ func (c *systemdController) StopInstance(ctx context.Context, instance string) e
 	}
 	cmd.Env = env
 
-	fmt.Printf("Stopping service '%s' with command: %s %s\n", service, cmd.Path, strings.Join(cmd.Args, " "))
+	log.Printf("Attempting to stop service '%s'", service)
 
-	err = cmd.Run()
-	if err != nil {
-		// Check if the service is actually still active.
-		isActive, checkErr := c.isServiceActive(service)
-		if checkErr != nil {
-			return fmt.Errorf("failed to check service status after stop attempt: %w", checkErr)
-		}
-		if isActive {
-			return fmt.Errorf("failed to stop service '%s': %w", service, err)
-		}
-		// If it's not active, we can consider the stop successful, even if cmd.Run() returned an error.
-		log.Printf("Service '%s' was already stopped. Stop operation considered successful.", service)
-	} else {
-		log.Printf("Successfully stopped service '%s'\n", service)
+	// Issue the stop command. The command itself doesn't wait for shutdown.
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to issue stop command for service '%s': %w", service, err)
 	}
 
-	return nil
+	// Poll the service status to ensure it has fully shut down.
+	log.Printf("Waiting for service '%s' to be fully stopped...", service)
+
+	// Default to a 5-second timeout for graceful shutdown.
+	// Todo: Configurable timeout
+	pollingCtx, pollingCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer pollingCancel()
+
+	ticker := time.NewTicker(200 * time.Millisecond) // Poll every 200ms
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-pollingCtx.Done():
+			return fmt.Errorf("service '%s' did not stop gracefully within the timeout: %w", service, pollingCtx.Err())
+		case <-ticker.C:
+			isActive, checkErr := c.isServiceActive(service)
+			if checkErr != nil {
+				return fmt.Errorf("failed to check service status during graceful stop: %w", checkErr)
+			}
+			if !isActive {
+				log.Printf("Service '%s' is confirmed stopped.", service)
+				return nil
+			}
+		}
+	}
 }
 
 // RestartInstance stops and then starts a systemd user service instance.
 func (c *systemdController) RestartInstance(ctx context.Context, instanceName string) error {
 	log.Printf("Attempting to restart instance '%s'...", instanceName)
 
-	// Stop the service.
-	log.Printf("Stopping service for instance '%s'...", instanceName)
-	err := c.StopInstance(ctx, instanceName)
-	if err != nil {
-		return fmt.Errorf("failed to stop instance '%s' for restart: %w", instanceName, err)
-	}
-
-	// Wait till the service is shut down completely.
-	log.Printf("Waiting for service '%s' to be fully stopped...", instanceName)
-	pollingCtx, pollingCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer pollingCancel()
-
-	// Check the service status until it's inactive.
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-loop:
-	for {
-		select {
-		case <-pollingCtx.Done():
-			return fmt.Errorf("service '%s' did not stop in time for restart", instanceName)
-		case <-ticker.C:
-			isActive, err := c.isServiceActive(instanceName)
-			if err != nil {
-				return fmt.Errorf("failed to check status of '%s' during restart: %w", instanceName, err)
-			}
-			if !isActive {
-				log.Printf("Service '%s' is confirmed stopped.", instanceName)
-				break loop
-			}
-		}
+	// Stop the service gracefully.
+	if err := c.StopInstance(ctx, instanceName); err != nil {
+		return fmt.Errorf("failed to gracefully stop instance '%s' for restart: %w", instanceName, err)
 	}
 
 	// Start the service.
-	log.Printf("Starting service for instance '%s'...", instanceName)
-	err = c.StartInstance(ctx, instanceName)
-	if err != nil {
+	if err := c.StartInstance(ctx, instanceName); err != nil {
 		return fmt.Errorf("failed to start instance '%s' after stop: %w", instanceName, err)
 	}
 
@@ -157,7 +172,26 @@ func (c *systemdController) getUserSystemdEnv() ([]string, error) {
 	return finalEnv, nil
 }
 
-// Helper function to check service status
+// checkServiceExists checks if a service file exists.
+func (c *systemdController) checkServiceExists(serviceName string) (bool, error) {
+	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+	err := cmd.Run()
+	if err == nil {
+		// Service is active, exists.
+		return true, nil
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		// Exit code 4 means the service unit does not exist.
+		if exitError.ExitCode() == 4 {
+			return false, nil
+		}
+		// service exists but is not running.
+		return true, nil
+	}
+	return false, err
+}
+
+// isServiceActive checks if a service is currently active.
 func (c *systemdController) isServiceActive(serviceName string) (bool, error) {
 	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
 	err := cmd.Run()
@@ -173,19 +207,15 @@ func (c *systemdController) isServiceActive(serviceName string) (bool, error) {
 	return false, err
 }
 
-// windowsController implements InstanceController for Windows using PowerShell.
+// windowsController implements InstanceController for Windows.
 type windowsController struct{}
 
 func (c *windowsController) StartInstance(ctx context.Context, instance string) error {
-	service := fmt.Sprintf("hydraserver-%s", instance)
-	cmd := exec.Command("powershell", "Start-Service", service)
-	return cmd.Run()
+	return nil
 }
 
 func (c *windowsController) StopInstance(ctx context.Context, instance string) error {
-	service := fmt.Sprintf("hydraserver-%s", instance)
-	cmd := exec.Command("powershell", "Stop-Service", service)
-	return cmd.Run()
+	return nil
 }
 
 func (c *windowsController) RestartInstance(ctx context.Context, instance string) error {

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
@@ -1,0 +1,166 @@
+package instancerunner
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// IMPORTANT MANUAL STEP
+// CREATE A VALID SERVICE FILE TO PERFORM THIS TEST OR MAKE SURE IT EXISTS
+var serviceName = "hydraserver-test5.service"
+var instanceName = "test5"
+
+func TestStartInstance(t *testing.T) {
+
+	// We make sure the service not already running
+	stopCmd := exec.Command("systemctl", "--user", "stop", serviceName)
+	stopCmd.Run()
+
+	// It ensures the service is stopped to prevent interference with other tests.
+	t.Cleanup(func() {
+		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+	})
+
+	instance := NewInstanceController()
+	if _, ok := instance.(*systemdController); !ok {
+		t.Fatal("Expected systemdController, got a different type")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Logf("Calling StartInstance for '%s'", serviceName)
+	err := instance.StartInstance(ctx, instanceName)
+	if err != nil {
+		t.Fatalf("StartInstance failed with error: %v", err)
+	}
+
+	// Give systemd a moment to update its state
+	time.Sleep(1 * time.Second)
+
+	t.Log("Verifying service is up...")
+	isActive, err := isServiceActive(serviceName)
+	if err != nil {
+		t.Fatalf("Failed to check service status: %v", err)
+	}
+
+	if !isActive {
+		t.Fatal("Service is not running after being started")
+	}
+
+	t.Logf("Service '%s' is up and running.", serviceName)
+}
+
+func TestStopInstance(t *testing.T) {
+	instance := NewInstanceController()
+	if _, ok := instance.(*systemdController); !ok {
+		t.Fatal("Expected systemdController, got a different type")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start the service once to ensure it can be started
+	if err := instance.StartInstance(ctx, instanceName); err != nil {
+		t.Fatalf("Pre-start failed: %v", err)
+	}
+
+	// Wait for service to be up and running
+	time.Sleep(1 * time.Second)
+	isActive, err := isServiceActive(serviceName)
+	if err != nil {
+		t.Fatalf("Failed to check service status after start: %v", err)
+	}
+	if !isActive {
+		t.Fatalf("Service '%s' is not active. Cannot test stop functionality.", serviceName)
+	}
+	t.Logf("Service '%s' is confirmed to be running.", serviceName)
+
+	t.Cleanup(func() {
+		// Clean up by stopping the service at the end, just in case
+		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+	})
+
+	t.Logf("Calling StopInstance for '%s'", instanceName)
+	err = instance.StopInstance(ctx, instanceName)
+	if err != nil {
+		t.Fatalf("StopInstance failed with unexpected error: %v", err)
+	}
+
+	// Give systemd a moment to update its state
+	time.Sleep(1 * time.Second)
+
+	t.Log("Verifying service is stopped...")
+	isActive, err = isServiceActive(serviceName)
+	if err != nil {
+		t.Fatalf("Failed to check service status after stop: %v", err)
+	}
+
+	if isActive {
+		t.Fatal("Service is still running after being stopped")
+	}
+
+	t.Logf("Service '%s' is successfully stopped.", serviceName)
+}
+
+func TestRestartInstance(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Ensure the service is not running before the test.
+	stopCmd := exec.Command("systemctl", "--user", "stop", serviceName)
+	stopCmd.Run() // Don't check error, as it might already be stopped
+
+	// Clean up after the test.
+	t.Cleanup(func() {
+		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+	})
+
+	instance := NewInstanceController()
+	if _, ok := instance.(*systemdController); !ok {
+		t.Fatal("Expected systemdController")
+	}
+
+	// Start the service once to ensure it can be started
+	if err := instance.StartInstance(ctx, instanceName); err != nil {
+		t.Fatalf("Pre-start failed: %v", err)
+	}
+
+	// Give the service a moment to stabilize
+	time.Sleep(1 * time.Second)
+
+	// Call the restart function
+	if err := instance.RestartInstance(ctx, instanceName); err != nil {
+		t.Fatalf("RestartInstance failed unexpectedly: %v", err)
+	}
+
+	// Give the service a moment to finish restarting
+	time.Sleep(1 * time.Second)
+
+	// Verify the service is up after the restart.
+	isActive, err := isServiceActive(serviceName)
+	if err != nil {
+		t.Fatalf("Failed to check service status after restart: %v", err)
+	}
+	if !isActive {
+		t.Fatal("Service is not running after being restarted")
+	}
+}
+
+// Helper function to check service status
+func isServiceActive(serviceName string) (bool, error) {
+	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		// Inactive service
+		if exitError.ExitCode() == 3 {
+			return false, nil
+		}
+	}
+	return false, err
+}

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
@@ -2,23 +2,37 @@ package instancerunner
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
 )
 
-// IMPORTANT MANUAL STEP
-// CREATE A VALID SERVICE FILE TO PERFORM THIS TEST OR MAKE SURE IT EXISTS
+// IMPORTANT MANUAL STEP:
+// CREATE A VALID SERVICE FILE TO PERFORM THIS TEST OR MAKE SURE IT EXISTS.
+// Example:
+// Create a file named 'hydraserver-test5.service' in ~/.config/systemd/user/
+// with the following content:
+//
+// [Unit]
+// Description=HydrAIDE Test Service
+//
+// [Service]
+// ExecStart=/bin/bash -c "while true; do echo 'Service running...'; sleep 1; done"
+// Restart=always
+//
+// [Install]
+// WantedBy=default.target
+//
+// After creating the file, run 'systemctl --user daemon-reload'
 var serviceName = "hydraserver-test5.service"
 var instanceName = "test5"
 
 func TestStartInstance(t *testing.T) {
-
 	// We make sure the service not already running
 	stopCmd := exec.Command("systemctl", "--user", "stop", serviceName)
 	stopCmd.Run()
 
-	// It ensures the service is stopped to prevent interference with other tests.
 	t.Cleanup(func() {
 		exec.Command("systemctl", "--user", "stop", serviceName).Run()
 	})
@@ -59,24 +73,14 @@ func TestStopInstance(t *testing.T) {
 		t.Fatal("Expected systemdController, got a different type")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// Start the service once to ensure it can be started
+	// Ensure the service is running before attempting to stop.
 	if err := instance.StartInstance(ctx, instanceName); err != nil {
 		t.Fatalf("Pre-start failed: %v", err)
 	}
-
-	// Wait for service to be up and running
-	time.Sleep(1 * time.Second)
-	isActive, err := isServiceActive(serviceName)
-	if err != nil {
-		t.Fatalf("Failed to check service status after start: %v", err)
-	}
-	if !isActive {
-		t.Fatalf("Service '%s' is not active. Cannot test stop functionality.", serviceName)
-	}
-	t.Logf("Service '%s' is confirmed to be running.", serviceName)
+	time.Sleep(1 * time.Second) // Wait for complete start before proceeding.
 
 	t.Cleanup(func() {
 		// Clean up by stopping the service at the end, just in case
@@ -84,16 +88,13 @@ func TestStopInstance(t *testing.T) {
 	})
 
 	t.Logf("Calling StopInstance for '%s'", instanceName)
-	err = instance.StopInstance(ctx, instanceName)
+	err := instance.StopInstance(ctx, instanceName)
 	if err != nil {
 		t.Fatalf("StopInstance failed with unexpected error: %v", err)
 	}
 
-	// Give systemd a moment to update its state
-	time.Sleep(1 * time.Second)
-
 	t.Log("Verifying service is stopped...")
-	isActive, err = isServiceActive(serviceName)
+	isActive, err := isServiceActive(serviceName)
 	if err != nil {
 		t.Fatalf("Failed to check service status after stop: %v", err)
 	}
@@ -106,14 +107,13 @@ func TestStopInstance(t *testing.T) {
 }
 
 func TestRestartInstance(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	// Ensure the service is not running before the test.
 	stopCmd := exec.Command("systemctl", "--user", "stop", serviceName)
-	stopCmd.Run() // Don't check error, as it might already be stopped
+	stopCmd.Run()
 
-	// Clean up after the test.
 	t.Cleanup(func() {
 		exec.Command("systemctl", "--user", "stop", serviceName).Run()
 	})
@@ -127,19 +127,15 @@ func TestRestartInstance(t *testing.T) {
 	if err := instance.StartInstance(ctx, instanceName); err != nil {
 		t.Fatalf("Pre-start failed: %v", err)
 	}
-
-	// Give the service a moment to stabilize
 	time.Sleep(1 * time.Second)
 
-	// Call the restart function
+	t.Logf("Calling RestartInstance for '%s'", instanceName)
 	if err := instance.RestartInstance(ctx, instanceName); err != nil {
 		t.Fatalf("RestartInstance failed unexpectedly: %v", err)
 	}
 
-	// Give the service a moment to finish restarting
-	time.Sleep(1 * time.Second)
-
-	// Verify the service is up after the restart.
+	// The restart function now handles waiting, so we just need to check the final state.
+	t.Log("Verifying service is up after restart...")
 	isActive, err := isServiceActive(serviceName)
 	if err != nil {
 		t.Fatalf("Failed to check service status after restart: %v", err)
@@ -149,7 +145,30 @@ func TestRestartInstance(t *testing.T) {
 	}
 }
 
-// Helper function to check service status
+func TestMissingService(t *testing.T) {
+	instance := NewInstanceController()
+	if _, ok := instance.(*systemdController); !ok {
+		t.Fatal("Expected systemdController")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	missingInstanceName := "non-existent-test-service"
+
+	t.Logf("Testing StartInstance with a missing service '%s'", missingInstanceName)
+	err := instance.StartInstance(ctx, missingInstanceName)
+	if err == nil {
+		t.Fatal("Expected an error for a missing service, but got none")
+	}
+
+	expectedError := fmt.Sprintf("service 'hydraserver-%s.service' not found", missingInstanceName)
+	if err.Error() != expectedError {
+		t.Fatalf("Expected error '%s', but got '%s'", expectedError, err.Error())
+	}
+}
+
+// Helper function to check service status.
 func isServiceActive(serviceName string) (bool, error) {
 	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
 	err := cmd.Run()
@@ -157,8 +176,8 @@ func isServiceActive(serviceName string) (bool, error) {
 		return true, nil
 	}
 	if exitError, ok := err.(*exec.ExitError); ok {
-		// Inactive service
-		if exitError.ExitCode() == 3 {
+		// Inactive service or unknown unit
+		if exitError.ExitCode() == 3 || exitError.ExitCode() == 4 {
 			return false, nil
 		}
 	}

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
@@ -7,40 +7,47 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
 
+// Define a test instance name to use for creating temporary services.
 var instanceName = "temporary-test-service"
 
+// TestStartInstance verifies that the StartInstance function correctly starts a service.
 func TestStartInstance(t *testing.T) {
-	// Setup service
+	// Setup service dynamically based on the OS.
 	serviceName, err := createTestServiceFile()
 	if err != nil {
-		fmt.Printf("Failed to create service file: %s", err.Error())
-		t.Error(err)
+		t.Fatalf("Failed to create service file: %v", err)
 	}
-	// Stop service and remove service file post-test
+
+	// Ensure the service is stopped and removed after the test.
 	t.Cleanup(func() {
-		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+		stopCmd := exec.CommandContext(context.Background(), getStopCommand(), getStopArgs(serviceName)...)
+		stopCmd.Run()
 		removeTestServiceFile()
 	})
 
 	instance := NewInstanceController()
-	if _, ok := instance.(*systemdController); !ok {
-		t.Fatal("Expected systemdController, got a different type")
+	if _, ok := instance.(*systemdController); !ok && runtime.GOOS == "linux" {
+		t.Fatal("Expected systemdController for Linux, got a different type")
+	}
+	if _, ok := instance.(*windowsController); !ok && runtime.GOOS == "windows" {
+		t.Fatal("Expected windowsController for Windows, got a different type")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	t.Logf("Calling StartInstance for '%s'", serviceName)
+	t.Logf("Calling StartInstance for '%s' on %s", serviceName, runtime.GOOS)
 	err = instance.StartInstance(ctx, instanceName)
 	if err != nil {
 		t.Fatalf("StartInstance failed with error: %v", err)
 	}
 
-	// Give systemd a moment to update its state
+	// Give the service a moment to update its state.
 	time.Sleep(1 * time.Second)
 
 	t.Log("Verifying service is up...")
@@ -56,24 +63,22 @@ func TestStartInstance(t *testing.T) {
 	t.Logf("Service '%s' is up and running.", serviceName)
 }
 
+// TestStopInstance verifies that the StopInstance function correctly stops a running service.
 func TestStopInstance(t *testing.T) {
-	// Setup service
+	// Setup service dynamically based on the OS.
 	serviceName, err := createTestServiceFile()
 	if err != nil {
-		fmt.Printf("Failed to create service file: %s", err.Error())
-		t.Error(err)
+		t.Fatalf("Failed to create service file: %v", err)
 	}
-	// Stop service and remove service file post-test
+
+	// Ensure the service is stopped and removed after the test.
 	t.Cleanup(func() {
-		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+		stopCmd := exec.CommandContext(context.Background(), getStopCommand(), getStopArgs(serviceName)...)
+		stopCmd.Run()
 		removeTestServiceFile()
 	})
 
 	instance := NewInstanceController()
-	if _, ok := instance.(*systemdController); !ok {
-		t.Fatal("Expected systemdController, got a different type")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
@@ -83,7 +88,7 @@ func TestStopInstance(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second) // Wait for complete start before proceeding.
 
-	t.Logf("Calling StopInstance for '%s'", instanceName)
+	t.Logf("Calling StopInstance for '%s' on %s", instanceName, runtime.GOOS)
 	err = instance.StopInstance(ctx, instanceName)
 	if err != nil {
 		t.Fatalf("StopInstance failed with unexpected error: %v", err)
@@ -101,16 +106,18 @@ func TestStopInstance(t *testing.T) {
 	t.Logf("Service '%s' is successfully stopped.", serviceName)
 }
 
+// TestRestartInstance verifies that RestartInstance correctly stops and starts a service.
 func TestRestartInstance(t *testing.T) {
-	// Setup service
+	// Setup service dynamically based on the OS.
 	serviceName, err := createTestServiceFile()
 	if err != nil {
-		fmt.Printf("Failed to create service file: %s", err.Error())
-		t.Error(err)
+		t.Fatalf("Failed to create service file: %v", err)
 	}
-	// Stop service and remove service file post-test
+
+	// Ensure the service is stopped and removed after the test.
 	t.Cleanup(func() {
-		exec.Command("systemctl", "--user", "stop", serviceName).Run()
+		stopCmd := exec.CommandContext(context.Background(), getStopCommand(), getStopArgs(serviceName)...)
+		stopCmd.Run()
 		removeTestServiceFile()
 	})
 
@@ -118,21 +125,16 @@ func TestRestartInstance(t *testing.T) {
 	defer cancel()
 
 	// Ensure the service is not running before the test.
-	stopCmd := exec.Command("systemctl", "--user", "stop", serviceName)
-	stopCmd.Run()
+	exec.CommandContext(context.Background(), getStopCommand(), getStopArgs(serviceName)...).Run()
 
 	instance := NewInstanceController()
-	if _, ok := instance.(*systemdController); !ok {
-		t.Fatal("Expected systemdController")
-	}
-
 	// Start the service once to ensure it can be started
 	if err := instance.StartInstance(ctx, instanceName); err != nil {
 		t.Fatalf("Pre-start failed: %v", err)
 	}
 	time.Sleep(1 * time.Second)
 
-	t.Logf("Calling RestartInstance for '%s'", instanceName)
+	t.Logf("Calling RestartInstance for '%s' on %s", instanceName, runtime.GOOS)
 	if err := instance.RestartInstance(ctx, instanceName); err != nil {
 		t.Fatalf("RestartInstance failed unexpectedly: %v", err)
 	}
@@ -148,55 +150,83 @@ func TestRestartInstance(t *testing.T) {
 	}
 }
 
+// TestMissingService verifies that an error is returned when a non-existent service is requested.
 func TestMissingService(t *testing.T) {
 	instance := NewInstanceController()
-	if _, ok := instance.(*systemdController); !ok {
-		t.Fatal("Expected systemdController")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	missingInstanceName := "non-existent-test-service"
-	t.Logf("Testing StartInstance with a missing service '%s'", missingInstanceName)
+	t.Logf("Testing StartInstance with a missing service '%s' on %s", missingInstanceName, runtime.GOOS)
 	err := instance.StartInstance(ctx, missingInstanceName)
 	if err == nil {
 		t.Fatal("Expected an error for a missing service, but got none")
 	}
 
-	expectedError := fmt.Sprintf("service 'hydraserver-%s.service' not found", missingInstanceName)
+	// Verify the error message matches the expected format for the given OS.
+	var expectedError string
+	switch runtime.GOOS {
+	case "linux":
+		expectedError = fmt.Sprintf("service 'hydraserver-%s.service' not found", missingInstanceName)
+	case "windows":
+		expectedError = fmt.Sprintf("service 'hydraserver-%s' not found", missingInstanceName)
+	}
+
 	if err.Error() != expectedError {
 		t.Fatalf("Expected error '%s', but got '%s'", expectedError, err.Error())
 	}
 }
 
-// Helper function to check service status.
+// isServiceActive is a helper function to check if a service is currently active,
+// adapting the command based on the OS.
 func isServiceActive(serviceName string) (bool, error) {
-	cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
-	err := cmd.Run()
-	if err == nil {
-		return true, nil
-	}
-	if exitError, ok := err.(*exec.ExitError); ok {
-		// Inactive service or unknown unit
-		if exitError.ExitCode() == 3 || exitError.ExitCode() == 4 {
+	switch runtime.GOOS {
+	case "linux":
+		cmd := exec.Command("systemctl", "--user", "is-active", "--quiet", serviceName)
+		err := cmd.Run()
+		if err == nil {
+			return true, nil
+		}
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 3 || exitError.ExitCode() == 4 {
+				return false, nil
+			}
+		}
+		return false, err
+	case "windows":
+		// Use powershell to get service status.
+		// 'Get-Service' returns a non-zero exit code if the service does not exist.
+		cmd := exec.Command("powershell", "-Command", fmt.Sprintf("(Get-Service '%s').Status -eq 'Running'", serviceName))
+		output, err := cmd.Output()
+		if err != nil {
+			// Service not found or some other error occurred.
 			return false, nil
 		}
+		return strings.TrimSpace(string(output)) == "True", nil
 	}
-	return false, err
+	return false, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 }
 
-// createTestServiceFile creates a dummy systemd user service file for testing purposes.
-// It returns the service name to the created service file.
+// createTestServiceFile creates a dummy service file/entry for testing purposes,
+// adapting the method based on the OS.
 func createTestServiceFile() (string, error) {
-	if runtime.GOOS != "linux" {
-		return "", fmt.Errorf("Only linux OS is supported.")
+	switch runtime.GOOS {
+	case "linux":
+		return createLinuxTestServiceFile()
+	case "windows":
+		return createWindowsTestServiceFile()
 	}
+	return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+}
 
+// createLinuxTestServiceFile creates a dummy systemd user service file.
+func createLinuxTestServiceFile() (string, error) {
+
+	// Replace ExecStart with actual hydraide service binpath and workdir for E2E test.
 	content := `
 		[Unit]
 		Description=HydrAIDE Test Service
-		
+
 		[Service]
 		ExecStart=/bin/bash -c "while true; do echo 'Service running...'; sleep 1; done"
 		Restart=always
@@ -214,18 +244,14 @@ func createTestServiceFile() (string, error) {
 	serviceFile := fmt.Sprintf("hydraserver-%s.service", instanceName)
 	fullPath := filepath.Join(serviceDir, serviceFile)
 
-	// Create the directory if it doesn't exist
 	if err := os.MkdirAll(serviceDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create service directory: %w", err)
 	}
 
-	// Write the service file content
 	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
 		return "", fmt.Errorf("failed to write service file: %w", err)
 	}
 
-	// Reload the systemd daemon to pick up the new service file.
-	// This is a crucial step for the tests to work.
 	cmd := exec.Command("systemctl", "--user", "daemon-reload")
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to run 'systemctl --user daemon-reload': %w", err)
@@ -234,17 +260,58 @@ func createTestServiceFile() (string, error) {
 	return serviceFile, nil
 }
 
-// removeTestServiceFile stops the service and removes the file created by createTestServiceFile.
+// createWindowsTestServiceFile creates a dummy Windows service using sc.exe.
+func createWindowsTestServiceFile() (string, error) {
+	serviceName := fmt.Sprintf("hydraserver-%s", instanceName)
+	cmd := exec.Command("sc", "create", serviceName, "binPath=", `cmd.exe /c "ping 127.0.0.1 -n 60 >nul"`, "start=", "demand")
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to create Windows service '%s': %w", serviceName, err)
+	}
+	return serviceName, nil
+}
+
+// removeTestServiceFile stops the service and removes the service entry.
 func removeTestServiceFile() {
+	switch runtime.GOOS {
+	case "linux":
+		removeLinuxTestServiceFile()
+	case "windows":
+		removeWindowsTestServiceFile()
+	}
+}
+
+// removeLinuxTestServiceFile removes a dummy systemd user service file.
+func removeLinuxTestServiceFile() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
 	serviceFile := fmt.Sprintf("hydraserver-%s.service", instanceName)
 	fullPath := filepath.Join(homeDir, ".config", "systemd", "user", serviceFile)
-
-	// Stop the service before attempting to remove the file
 	exec.Command("systemctl", "--user", "stop", serviceFile).Run()
 	os.Remove(fullPath)
 	exec.Command("systemctl", "--user", "daemon-reload").Run()
+}
+
+// removeWindowsTestServiceFile removes a dummy Windows service.
+func removeWindowsTestServiceFile() {
+	serviceName := fmt.Sprintf("hydraserver-%s", instanceName)
+	exec.Command("sc", "stop", serviceName).Run()
+	exec.Command("sc", "delete", serviceName).Run()
+}
+
+// getStopCommand returns the appropriate command for stopping a service based on the OS.
+func getStopCommand() string {
+	if runtime.GOOS == "linux" {
+		return "systemctl"
+	}
+	return "sc"
+}
+
+// getStopArgs returns the arguments for the stop command based on the OS.
+func getStopArgs(serviceName string) []string {
+	if runtime.GOOS == "linux" {
+		return []string{"--user", "stop", serviceName}
+	}
+	return []string{"stop", serviceName}
 }

--- a/app/hydraidectl/cmd/utils/instancerunner/locker/locker.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/locker/locker.go
@@ -1,0 +1,32 @@
+package locker
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Locker manages a file-based lock for a single HydrAIDE instance.
+// This provides an inter-process locking mechanism to ensure only one lifecycle
+// command can be executed for a given instance at a time, even across separate CLI processes.
+type Locker interface {
+	// Lock acquires a file lock for the instance.
+	// It will block until the lock is available.
+	Lock() error
+
+	// Unlock releases the file lock.
+	Unlock() error
+}
+
+// NewLocker creates a new file-based locker for a given instance name.
+// It creates the lock file in a standard location (~/.hydraide/locks) and returns
+// an error if it cannot be created or opened.
+func NewLocker(instanceName string) (Locker, error) {
+	switch runtime.GOOS {
+	case "windows":
+		return newWindowsLocker(instanceName)
+	case "linux":
+		return newPosixLocker(instanceName)
+	default:
+		return nil, fmt.Errorf("locker: unsupported platform")
+	}
+}

--- a/app/hydraidectl/cmd/utils/instancerunner/locker/locker_linux.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/locker/locker_linux.go
@@ -1,0 +1,62 @@
+//go:build !windows
+// +build !windows
+
+package locker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type posixLocker struct {
+	file *os.File
+}
+
+func newPosixLocker(instanceName string) (Locker, error) {
+	dir, err := getLockDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, instanceName+".lock")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("posixLocker: open lock file: %w", err)
+	}
+	return &posixLocker{file: f}, nil
+}
+
+func (l *posixLocker) Lock() error {
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("failed to acquire file lock: %w", err)
+	}
+	return nil
+}
+
+func (l *posixLocker) Unlock() error {
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("failed to release file lock: %w", err)
+	}
+	l.file.Close()
+	return nil
+}
+
+// getLockDirectory returns the path to the directory where lock files are stored.
+// It creates the directory if it does not exist.
+func getLockDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".hydraide", "locks")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// Stub function for linux: Used when compiled/compiling in linux
+func newWindowsLocker(_ string) (Locker, error) {
+	return nil, fmt.Errorf("not compiled in linux")
+}

--- a/app/hydraidectl/cmd/utils/instancerunner/locker/locker_windows.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/locker/locker_windows.go
@@ -1,0 +1,80 @@
+//go:build windows
+// +build windows
+
+package locker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// windowsLocker uses Win32 LockFileEx/UnlockFileEx on a small file.
+type windowsLocker struct {
+	handle windows.Handle
+}
+
+func newWindowsLocker(instanceName string) (Locker, error) {
+	dir, err := getLockDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, instanceName+".lock")
+
+	// OPEN_ALWAYS, GENERIC_READ|GENERIC_WRITE, share read/write
+	h, err := windows.CreateFile(
+		windows.StringToUTF16Ptr(path),
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("windowsLocker: CreateFile: %w", err)
+	}
+	return &windowsLocker{handle: h}, nil
+}
+
+func (l *windowsLocker) Lock() error {
+	ol := new(windows.Overlapped)
+	// LOCKFILE_EXCLUSIVE_LOCK = 2
+	return windows.LockFileEx(
+		l.handle,
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1, 0, // lock 1 byte
+		ol,
+	)
+}
+
+func (l *windowsLocker) Unlock() error {
+	ol := new(windows.Overlapped)
+	if err := windows.UnlockFileEx(l.handle, 0, 1, 0, ol); err != nil {
+		return fmt.Errorf("windowsLocker: UnlockFileEx: %w", err)
+	}
+	return windows.CloseHandle(l.handle)
+}
+
+// getLockDirectory returns the path to the directory where lock files are stored.
+// It creates the directory if it does not exist.
+func getLockDir() (string, error) {
+	// identical to posix getLockDir
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".hydraide", "locks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// Stub function for linux: Used when compiled/compiling in windows
+func newPosixLocker(_ string) (Locker, error) {
+	return nil, fmt.Errorf("not compiled in linux")
+}


### PR DESCRIPTION

## 🧩 What does this PR do?

Feature: Instance-Aware Service Lifecycle Helper
This pull request introduces a reusable service control helper under utils/instancerunner to manage the lifecycle of HydrAIDE instances. This solves the problem of needing a unified, programmatic way to start, stop, and restart services without relying on manual systemctl commands.

---

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #46 
Relates to #51 

---

## Solution description
The solution is a new InstanceController interface and its implementation for Linux, systemdController, which provides a robust and concurrency-safe way to manage services. The key components of this solution are:

**InstanceController Interface:** Defines a clear contract for managing instances with StartInstance, StopInstance, and RestartInstance methods.

**File-Based Locking (instanceLocker):** A critical component that ensures concurrency safety. By using system-level locks on a lock file (eg, ~/.hydraide/locks/<instance>.lock), the application prevents multiple lifecycle commands from executing on the same instance **simultaneously by different users/cli-iinstances**. This is essential for preventing race conditions or perform safe operations.

Key Implementation Details
Concurrency Safety: Each public method (StartInstance, StopInstance, RestartInstance) acquires a file lock for the duration of its execution. The RestartInstance method is specifically designed to acquire the lock once and then call internal, "unlocked" helper functions (startInstanceUnlocked and stopInstanceUnlocked) to perform the stop-and-start sequence, preventing a deadlock.

Unit Testability: The implementation is exposed via an interface, allowing for easy mocking in future tests. The accompanying instancerunner_test.go includes tests for starting, stopping, and restarting services, as well as a test case for a missing service.

This implementation provides a robust and reliable foundation for managing HydrAIDE instances within the hydraidectl CLI framework.

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [x] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [x] All new code has appropriate test coverage
- [x] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers

<!-- Any special review notes, instructions, or context goes here -->
