### PR TITLE
Feat/instancerunner 49

### DIFF
--- a/app/hydraidectl/cmd/restart.go
+++ b/app/hydraidectl/cmd/restart.go
@@ -1,22 +1,93 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner"
 	"github.com/spf13/cobra"
 )
+
+var restartInstance string
 
 var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restart the HydrAIDE container",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		fmt.Println("🔁 Restarting HydrAIDE...")
+		instanceController := instancerunner.NewInstanceController(
+			instancerunner.WithTimeout(30*time.Second),
+			instancerunner.WithGracefulStartStopTimeout(10*time.Second),
+		)
 
-		// todo: get the instance name
+		if instanceController == nil {
+			fmt.Printf("❌ unsupported operating system: %s", runtime.GOOS)
+			return
+		}
 
+		ctx := context.Background()
+
+		// Stop the instance
+		fmt.Printf("🔁 Restarting instance \"%s\"...\n", restartInstance)
+
+		err := instanceController.StopInstance(ctx, restartInstance)
+
+		if err != nil {
+			switch {
+			case errors.Is(err, instancerunner.ErrServiceNotFound):
+				fmt.Printf("❌ Instance \"%s\" not found.\n", restartInstance)
+				// Todo: Change the message when list-instances is available
+				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
+				os.Exit(1)
+
+			case errors.Is(err, instancerunner.ErrServiceNotRunning):
+				fmt.Printf("🟡 Instance \"%s\" is already stopped. No action taken.\n", restartInstance)
+				os.Exit(2)
+
+			default:
+				var cmdErr *instancerunner.CmdError
+				if errors.As(err, &cmdErr) {
+					fmt.Printf("❌ Failed to stop instance '%s': %v\nOutput: %s\n", restartInstance, cmdErr.Err, cmdErr.Output)
+				} else {
+					fmt.Printf("❌ Failed to stop instance '%s': %v\n", restartInstance, err)
+				}
+				os.Exit(3)
+			}
+		} else {
+			fmt.Printf("✅ Instance \"%s\" has been stopped. Status: inactive\n", restartInstance)
+		}
+
+		// We only proceed with the start if the stop phase didn't have a fatal error.
+		// A fatal error would have already exited the program above.
+		err = instanceController.StartInstance(ctx, restartInstance)
+
+		if err != nil {
+
+			var opErr *instancerunner.OperationError
+
+			if errors.As(err, &opErr) {
+				fmt.Printf("❌ Failed to start instance '%s': %v\n", restartInstance, opErr)
+			} else {
+				fmt.Printf("❌ Failed to start instance '%s': %v\n", restartInstance, err)
+			}
+			os.Exit(3)
+		}
+
+		fmt.Printf("✅ Restart complete. Status: active\n")
 	},
+
+	//   Currently, instancerunner, handles the graceful shutdown - need to continously print till we get a return.
+	//  todo: During the shutdown, it's highly recommended to periodically inform the user
+	//   that the shutdown is still in progress — and **strongly advise** them not to shut down the server/PC
 }
 
 func init() {
 	rootCmd.AddCommand(restartCmd)
+
+	restartCmd.Flags().StringVarP(&restartInstance, "instance", "i", "", "Name of the service instance")
+	restartCmd.MarkFlagRequired("instance")
 }

--- a/app/hydraidectl/cmd/restart.go
+++ b/app/hydraidectl/cmd/restart.go
@@ -31,17 +31,25 @@ var restartCmd = &cobra.Command{
 
 		ctx := context.Background()
 
+		exists, err := instanceController.InstanceExists(ctx, restartInstance)
+		if err != nil {
+			fmt.Println("failed to verify instance existence: ", err)
+		}
+
+		if !exists {
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
+			os.Exit(1)
+		}
+
 		// Stop the instance
 		fmt.Printf("🔁 Restarting instance \"%s\"...\n", restartInstance)
 
-		err := instanceController.StopInstance(ctx, restartInstance)
+		err = instanceController.StopInstance(ctx, restartInstance)
 
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\n", restartInstance)
-				// Todo: Change the message when list-instances is available
-				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceNotRunning):

--- a/app/hydraidectl/cmd/start.go
+++ b/app/hydraidectl/cmd/start.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner"
+	"github.com/spf13/cobra"
+)
+
+var startInstance string
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the HydrAIDE instance",
+	Run: func(cmd *cobra.Command, args []string) {
+		instanceController := instancerunner.NewInstanceController(
+			instancerunner.WithTimeout(20*time.Second),
+			instancerunner.WithGracefulStartStopTimeout(10*time.Second),
+		)
+		context := context.Background()
+		err := instanceController.StartInstance(context, startInstance)
+
+		if err != nil {
+			switch {
+			case errors.Is(err, instancerunner.ErrServiceNotFound):
+				fmt.Printf("❌ Instance \"%s\" not found.\n", startInstance)
+				// Todo: Change the message when list-instances is available
+				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+				os.Exit(1)
+
+			case errors.Is(err, instancerunner.ErrServiceAlreadyRunning):
+				fmt.Printf("🟡 Instance \"%s\" is already running. No action taken.\n", startInstance)
+				os.Exit(2)
+
+			default:
+				var cmdErr *instancerunner.CmdError
+				if errors.As(err, &cmdErr) {
+					fmt.Printf("❌ Failed to start instance '%s': %v\nOutput: %s\n", startInstance, cmdErr.Err, cmdErr.Output)
+				} else {
+					fmt.Printf("❌ Failed to start instance '%s': %v\n", startInstance, err)
+				}
+				os.Exit(3)
+			}
+		}
+		fmt.Printf("✅ Instance \"%s\" successfully started. Status: active\n", startInstance)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+
+	startCmd.Flags().StringVarP(&startInstance, "instance", "i", "", "Name of the service instance")
+	startCmd.MarkFlagRequired("instance")
+}

--- a/app/hydraidectl/cmd/start.go
+++ b/app/hydraidectl/cmd/start.go
@@ -18,6 +18,7 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the HydrAIDE instance",
 	Run: func(cmd *cobra.Command, args []string) {
+
 		instanceController := instancerunner.NewInstanceController(
 			instancerunner.WithTimeout(20*time.Second),
 			instancerunner.WithGracefulStartStopTimeout(10*time.Second),
@@ -28,15 +29,24 @@ var startCmd = &cobra.Command{
 			return
 		}
 
-		context := context.Background()
-		err := instanceController.StartInstance(context, startInstance)
+		ctx := context.Background()
+
+		exists, err := instanceController.InstanceExists(ctx, startInstance)
+		if err != nil {
+			fmt.Println("failed to verify instance existence: ", err)
+		}
+
+		if !exists {
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+			os.Exit(1)
+		}
+
+		err = instanceController.StartInstance(ctx, startInstance)
 
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\n", startInstance)
-				// Todo: Change the message when list-instances is available
-				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceAlreadyRunning):

--- a/app/hydraidectl/cmd/start.go
+++ b/app/hydraidectl/cmd/start.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner"
@@ -21,6 +22,12 @@ var startCmd = &cobra.Command{
 			instancerunner.WithTimeout(20*time.Second),
 			instancerunner.WithGracefulStartStopTimeout(10*time.Second),
 		)
+
+		if instanceController == nil {
+			fmt.Printf("❌ unsupported operating system: %s", runtime.GOOS)
+			return
+		}
+
 		context := context.Background()
 		err := instanceController.StartInstance(context, startInstance)
 

--- a/app/hydraidectl/cmd/stop.go
+++ b/app/hydraidectl/cmd/stop.go
@@ -31,17 +31,25 @@ var stopCmd = &cobra.Command{
 
 		ctx := context.Background()
 
+		exists, err := instanceController.InstanceExists(ctx, stopInstance)
+		if err != nil {
+			fmt.Println("failed to verify instance existence: ", err)
+		}
+
+		if !exists {
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
+			os.Exit(1)
+		}
+
 		fmt.Printf("🟡 Shutting down instance \"%s\"...\n", stopInstance)
 		fmt.Println("⚠️  HydrAIDE shutdown in progress... Do not power off or kill the service. Data may be flushing to disk.")
 
-		err := instanceController.StopInstance(ctx, stopInstance)
+		err = instanceController.StopInstance(ctx, stopInstance)
 
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\n", startInstance)
-				// Todo: Change the message when list-instances is available
-				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceNotRunning):

--- a/app/hydraidectl/cmd/stop.go
+++ b/app/hydraidectl/cmd/stop.go
@@ -41,7 +41,7 @@ var stopCmd = &cobra.Command{
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
 				fmt.Printf("❌ Instance \"%s\" not found.\n", startInstance)
 				// Todo: Change the message when list-instances is available
-				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceNotRunning):

--- a/app/hydraidectl/cmd/stop.go
+++ b/app/hydraidectl/cmd/stop.go
@@ -1,34 +1,76 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"time"
 
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner"
 	"github.com/spf13/cobra"
 )
+
+var stopInstance string
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the hydrAIDE instance",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		fmt.Println("⚠️ This will stop and remove your HydrAIDE setup.")
+		instanceController := instancerunner.NewInstanceController(
+			instancerunner.WithTimeout(20*time.Second),
+			instancerunner.WithGracefulStartStopTimeout(10*time.Second),
+		)
 
-		// TODO: This Stop command is responsible for stopping a running HydrAIDE instance by its name.
-		//  (IMPORTANT: This command must *not* delete the instance — it should only stop it if it is currently running.)
-		//  At the end of the command, report whether the instance was running and whether it was successfully stopped.
-		//  The process should be terminated using SIGTERM.
-		//
-		//  todo: IMPORTANT!! HydrAIDE performs a graceful shutdown when it receives a SIGTERM signal,
-		//   which means we must wait in the background until the shutdown actually completes.
-		//   Monitor the process and only notify the user once the process has fully terminated.
-		//
+		if instanceController == nil {
+			fmt.Printf("❌ unsupported operating system: %s", runtime.GOOS)
+			return
+		}
+
+		ctx := context.Background()
+
+		fmt.Printf("🟡 Shutting down instance \"%s\"...\n", stopInstance)
+		fmt.Println("⚠️  HydrAIDE shutdown in progress... Do not power off or kill the service. Data may be flushing to disk.")
+
+		err := instanceController.StopInstance(ctx, stopInstance)
+
+		if err != nil {
+			switch {
+			case errors.Is(err, instancerunner.ErrServiceNotFound):
+				fmt.Printf("❌ Instance \"%s\" not found.\n", startInstance)
+				// Todo: Change the message when list-instances is available
+				// fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+				os.Exit(1)
+
+			case errors.Is(err, instancerunner.ErrServiceNotRunning):
+				fmt.Printf("🟡 Instance \"%s\" is already stopped. No action taken.\n", stopInstance)
+				os.Exit(2)
+
+			default:
+				var cmdErr *instancerunner.CmdError
+				if errors.As(err, &cmdErr) {
+					fmt.Printf("❌ Failed to stop instance '%s': %v\nOutput: %s\n", stopInstance, cmdErr.Err, cmdErr.Output)
+				} else {
+					fmt.Printf("❌ Failed to stop instance '%s': %v\n", stopInstance, err)
+				}
+				os.Exit(3)
+			}
+		}
+
+		fmt.Printf("✅ Instance \"%s\" has been stopped. Status: inactive\n", stopInstance)
+
 		//  todo: During the shutdown, it's highly recommended to periodically inform the user
 		//   that the shutdown is still in progress — and **strongly advise** them not to shut down the server/PC
-		//   until the operation has finished, in order to avoid data loss.
+		//   Currently, instancerunner, handles the graceful shutdown - need to continously print till we get a return.
 
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(stopCmd)
+
+	stopCmd.Flags().StringVarP(&stopInstance, "instance", "i", "", "Name of the service instance")
+	stopCmd.MarkFlagRequired("instance")
 }

--- a/app/hydraidectl/cmd/utils/instancerunner/errors.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/errors.go
@@ -1,0 +1,74 @@
+package instancerunner
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrServiceAlreadyRunning is returned when a start command is issued for a
+// service that is already active.
+var ErrServiceAlreadyRunning = errors.New("service is already running")
+
+// ErrServiceNotRunning is returned when a stop or restart command is issued for a
+// service that is not currently active.
+var ErrServiceNotRunning = errors.New("service is not running")
+
+// ErrServiceNotFound is returned when a requested service does not exist on the system.
+var ErrServiceNotFound = errors.New("service not found")
+
+// CmdError is a generic error type for failures that occur while executing an
+// external command. It contains detailed information about the command,
+// its output, and the underlying error, which is crucial for debugging.
+type CmdError struct {
+	Command string
+	Output  string
+	Err     error
+}
+
+// Error implements the error interface for CmdError.
+func (e *CmdError) Error() string {
+	return fmt.Sprintf("command '%s' failed: %v\nOutput: %s", e.Command, e.Err, e.Output)
+}
+
+// Unwrap provides access to the underlying error.
+func (e *CmdError) Unwrap() error {
+	return e.Err
+}
+
+// OperationError is a high-level error returned when a lifecycle operation
+// (start, stop, restart) on a service fails for an internal reason. It is
+// designed to wrap low-level details.
+type OperationError struct {
+	Instance  string
+	Operation string
+	Err       error
+}
+
+// Error implements the error interface for OperationError.
+func (e *OperationError) Error() string {
+	return fmt.Sprintf("failed to perform %s on instance '%s': %v", e.Operation, e.Instance, e.Err)
+}
+
+// Unwrap provides access to the underlying error.
+func (e *OperationError) Unwrap() error {
+	return e.Err
+}
+
+// NewOperationError is a constructor that creates a new OperationError.
+func NewOperationError(instanceName, operation string, err error) error {
+	return &OperationError{
+		Instance:  instanceName,
+		Operation: operation,
+		Err:       err,
+	}
+}
+
+// NewCmdError is a constructor that creates a new CmdError.
+// It is used when system commands fail.
+func NewCmdError(command string, operation string, err error) error {
+	return &CmdError{
+		Command: command,
+		Output:  operation,
+		Err:     err,
+	}
+}

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner.go
@@ -2,6 +2,7 @@ package instancerunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -69,19 +70,29 @@ func (c *systemdController) StartInstance(ctx context.Context, instance string) 
 	// Pre-flight check: ensure the service file exists before attempting to start it.
 	exists, err := c.checkServiceExists(service)
 	if err != nil {
-		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+		return NewOperationError(instance, "check service existence", err)
 	}
 	if !exists {
-		return fmt.Errorf("service '%s' not found", service)
+		return ErrServiceNotFound
+	}
+
+	// Check if the service is already active.
+	isActive, err := c.isServiceActive(service)
+	if err != nil {
+		return NewOperationError(instance, "check service status", err)
+	}
+	if isActive {
+		logger.Info("Service is already running. No action needed.", "service_name", service)
+		return ErrServiceAlreadyRunning
 	}
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
 		logger.Error("Failed to get Instance Locker")
-		return err
+		return NewOperationError(instance, "get locker", err)
 	}
 	if err := locker.Lock(); err != nil {
-		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
+		return NewOperationError(instance, "lock instance", err)
 	}
 	logger.Debug("Locked instance", "instance_name", instance)
 	// Use defer to ensure the lock is always released when the function exits.
@@ -98,7 +109,11 @@ func (c *systemdController) startInstanceOp(ctx context.Context, service string)
 		logger.Info("Enable Service", "service_name", service)
 		enableCmd := exec.CommandContext(ctx, "systemctl", "enable", service)
 		if err := enableCmd.Run(); err != nil {
-			return fmt.Errorf("failed to enable service '%s': %w", service, err)
+			return NewOperationError(service, "enable service", &CmdError{
+				Command: "systemctl enable",
+				Output:  "",
+				Err:     err,
+			})
 		}
 	}
 
@@ -109,7 +124,7 @@ func (c *systemdController) startInstanceOp(ctx context.Context, service string)
 	err := cmd.Run()
 	if err != nil {
 		logger.Info("failed to start service", "service_name", service)
-		return fmt.Errorf("failed to start service '%s': %w", service, err)
+		return NewOperationError(service, "start service", NewCmdError("systemctl start", "", err))
 	}
 
 	logger.Info("Successfully started service", "service_name", service)
@@ -127,16 +142,16 @@ func (c *systemdController) StopInstance(ctx context.Context, instance string) e
 	// Pre-flight check: ensure the service file exists.
 	exists, err := c.checkServiceExists(service)
 	if err != nil {
-		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+		return NewOperationError(instance, "check service existence", err)
 	}
 	if !exists {
-		return fmt.Errorf("service '%s' not found", service)
+		return ErrServiceNotFound
 	}
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
 		logger.Error("Failed to get instance locker")
-		return err
+		return NewOperationError(instance, "Acquire lock", err)
 	}
 	if err := locker.Lock(); err != nil {
 		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
@@ -155,7 +170,7 @@ func (c *systemdController) stopInstanceOp(ctx context.Context, service string) 
 	isActive, err := c.isServiceActive(service)
 	if err != nil {
 		logger.Info("Failed to check status of", "service_name", service)
-		return fmt.Errorf("failed to check status of '%s': %w", service, err)
+		return NewOperationError(service, "check service status", err)
 	}
 	if !isActive {
 		logger.Info("Service is already stopped. No action needed.", "service_name", service)
@@ -168,7 +183,11 @@ func (c *systemdController) stopInstanceOp(ctx context.Context, service string) 
 
 	// Issue the stop command. The command itself doesn't wait for shutdown.
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to issue stop command for service '%s': %w", service, err)
+		return NewOperationError(service, "stop service", &CmdError{
+			Command: "systemctl stop",
+			Output:  "",
+			Err:     err,
+		})
 	}
 
 	// Poll the service status to ensure it has fully shut down.
@@ -184,11 +203,11 @@ func (c *systemdController) stopInstanceOp(ctx context.Context, service string) 
 	for {
 		select {
 		case <-pollingCtx.Done():
-			return fmt.Errorf("service '%s' did not stop gracefully within the timeout: %w", service, pollingCtx.Err())
+			return NewOperationError(service, "graceful stop", pollingCtx.Err())
 		case <-ticker.C:
 			isActive, checkErr := c.isServiceActive(service)
 			if checkErr != nil {
-				return fmt.Errorf("failed to check service status during graceful stop: %w", checkErr)
+				return NewOperationError(service, "check status during graceful stop", checkErr)
 			}
 			if !isActive {
 				logger.Info("Service is confirmed stopped.", "service_name", service)
@@ -210,20 +229,20 @@ func (c *systemdController) RestartInstance(ctx context.Context, instanceName st
 	// Pre-flight check: ensure the service file exists.
 	exists, err := c.checkServiceExists(service)
 	if err != nil {
-		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+		return NewOperationError(instanceName, "check service existence", err)
 	}
 	if !exists {
-		return fmt.Errorf("service '%s' not found", service)
+		return ErrServiceNotFound
 	}
 
 	// Acquire the lock for the entire restart operation.
 	locker, err := locker.NewLocker(instanceName)
 	if err != nil {
 		logger.Error("Failed to get instance locker")
-		return err
+		return NewOperationError(instanceName, "acquire locker", err)
 	}
 	if err := locker.Lock(); err != nil {
-		return fmt.Errorf("failed to lock instance '%s': %w", instanceName, err)
+		return NewOperationError(instanceName, "lock instance", err)
 	}
 	defer locker.Unlock()
 
@@ -231,13 +250,13 @@ func (c *systemdController) RestartInstance(ctx context.Context, instanceName st
 	// Stop the service gracefully.
 	logger.Debug("Stop Instance", "instance_name", instanceName)
 	if err := c.stopInstanceOp(ctx, service); err != nil {
-		return fmt.Errorf("failed to gracefully stop instance '%s' for restart: %w", instanceName, err)
+		return NewOperationError(instanceName, "stop for restart", err)
 	}
 
 	// Start the service.
 	logger.Debug("Start Instance", "instance_name", instanceName)
 	if err := c.startInstanceOp(ctx, service); err != nil {
-		return fmt.Errorf("failed to start instance '%s' after stop: %w", instanceName, err)
+		return NewOperationError(instanceName, "start after stop", err)
 	}
 
 	logger.Info("Successfully restarted instance", "instance_name", instanceName)
@@ -304,18 +323,18 @@ func (c *windowsController) StartInstance(ctx context.Context, instance string) 
 	// Check if the service exists before attempting to start.
 	exists, err := c.checkServiceExists(ctx, service)
 	if err != nil {
-		return fmt.Errorf("failed to check for service '%s' existence: %w", service, err)
+		return NewOperationError(instance, "check service existence", err)
 	}
 	if !exists {
-		return fmt.Errorf("service '%s' not found", service)
+		return ErrServiceNotFound
 	}
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
-		return err
+		return NewOperationError(instance, "acquire locker", err)
 	}
 	if err := locker.Lock(); err != nil {
-		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
+		return NewOperationError(instance, "lock instance", err)
 	}
 	// Use defer to ensure the lock is always released when the function exits.
 	defer locker.Unlock()
@@ -324,6 +343,15 @@ func (c *windowsController) StartInstance(ctx context.Context, instance string) 
 }
 
 func (c *windowsController) startInstanceOp(ctx context.Context, service string) error {
+	running, err := c.isServiceRunning(ctx, service)
+	if err != nil {
+		return NewOperationError(service, "check service status", err)
+	}
+	if running {
+		logger.Info("[windows] Service already running", "service_name", service)
+		return ErrServiceAlreadyRunning
+	}
+
 	logger.Info("[windows] Attempting to start service", "service_name", service)
 	var cmd *exec.Cmd
 	if c.useNssm {
@@ -332,9 +360,13 @@ func (c *windowsController) startInstanceOp(ctx context.Context, service string)
 		cmd = exec.CommandContext(ctx, "powershell", "-Command", fmt.Sprintf("Start-Service -Name '%s'", service))
 	}
 
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to start service '%s': %w", service, err)
+		return NewOperationError(service, "start service", &CmdError{
+			Command: fmt.Sprintf("start service for '%s'", service),
+			Output:  string(out),
+			Err:     err,
+		})
 	}
 
 	logger.Info("[windows] Successfully started service", "service_name", service)
@@ -350,18 +382,18 @@ func (c *windowsController) StopInstance(ctx context.Context, instance string) e
 
 	exists, err := c.checkServiceExists(ctx, service)
 	if err != nil {
-		return fmt.Errorf("failed to check for service '%s': %w", service, err)
+		return NewOperationError(instance, "check service existence", err)
 	}
 	if !exists {
-		return fmt.Errorf("service '%s' not found", service)
+		return ErrServiceNotFound
 	}
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
-		return err
+		return NewOperationError(instance, "acquire locker", err)
 	}
 	if err := locker.Lock(); err != nil {
-		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
+		return NewOperationError(instance, "lock instance", err)
 	}
 	defer locker.Unlock()
 
@@ -372,17 +404,27 @@ func (c *windowsController) stopInstanceOp(ctx context.Context, service string) 
 	// If already stopped, nothing to do
 	running, err := c.isServiceRunning(ctx, service)
 	if err != nil {
-		return fmt.Errorf("status check failed for '%s': %w", service, err)
+		return NewOperationError(service, "check service status", err)
 	}
 	if !running {
 		logger.Info("[windows] Service already stopped", "service_name", service)
-		return nil
+		return ErrServiceNotRunning
 	}
 
 	logger.Info("[windows] Stopping NSSM service", "service_name", service)
-	cmd := exec.CommandContext(ctx, "nssm", "stop", service)
+	var cmd *exec.Cmd
+	if c.useNssm {
+		cmd = exec.CommandContext(ctx, "nssm", "stop", service)
+	} else {
+		cmd = exec.CommandContext(ctx, "powershell", "-Command", fmt.Sprintf("Stop-Service -Name '%s'", service))
+	}
+
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("nssm stop failed: %v\n%s", err, out)
+		return NewOperationError(service, "stop service", &CmdError{
+			Command: fmt.Sprintf("stop service for '%s'", service),
+			Output:  string(out),
+			Err:     err,
+		})
 	}
 
 	// Poll until stopped or timeout
@@ -396,11 +438,11 @@ func (c *windowsController) stopInstanceOp(ctx context.Context, service string) 
 	for {
 		select {
 		case <-pollCtx.Done():
-			return fmt.Errorf("service '%s' did not stop within %s: %w", service, timeout, pollCtx.Err())
+			return NewOperationError(service, "graceful stop", pollCtx.Err())
 		case <-tick.C:
 			running, err := c.isServiceRunning(ctx, service)
 			if err != nil {
-				return fmt.Errorf("status check failed during stop poll: %w", err)
+				return NewOperationError(service, "status check during stop poll", err)
 			}
 			if !running {
 				logger.Info("[windows] Service confirmed stopped", "service_name", service)
@@ -419,19 +461,19 @@ func (c *windowsController) RestartInstance(ctx context.Context, instance string
 
 	locker, err := locker.NewLocker(instance)
 	if err != nil {
-		return err
+		return NewOperationError(instance, "acquire locker", err)
 	}
 	if err := locker.Lock(); err != nil {
-		return fmt.Errorf("failed to lock instance '%s': %w", instance, err)
+		return NewOperationError(instance, "lock instance", err)
 	}
 	defer locker.Unlock()
 
 	service := fmt.Sprintf("hydraserver-%s", instance)
-	if err := c.stopInstanceOp(ctx, service); err != nil {
-		return fmt.Errorf("failed to stop for restart: %w", err)
+	if err := c.stopInstanceOp(ctx, service); err != nil && !errors.Is(err, ErrServiceNotRunning) {
+		return NewOperationError(instance, "stop for restart", err)
 	}
 	if err := c.startInstanceOp(ctx, service); err != nil {
-		return fmt.Errorf("failed to start after stop: %w", err)
+		return NewOperationError(instance, "start after stop", err)
 	}
 	logger.Info("[windows] Successfully restarted", "service_name", instance)
 	return nil
@@ -447,7 +489,10 @@ func (c *windowsController) checkServiceExists(ctx context.Context, service stri
 			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
 				return false, nil // Service not installed
 			}
-			return false, fmt.Errorf("nssm check failed: %w", err)
+			return false, &CmdError{
+				Command: "nssm status",
+				Err:     err,
+			}
 		}
 		return true, nil
 	} else {
@@ -458,7 +503,10 @@ func (c *windowsController) checkServiceExists(ctx context.Context, service stri
 			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 				return false, nil // Service not found
 			}
-			return false, fmt.Errorf("powershell get-service failed: %w", err)
+			return false, &CmdError{
+				Command: "powershell Get-Service",
+				Err:     err,
+			}
 		}
 		return true, nil
 	}
@@ -470,14 +518,30 @@ func (c *windowsController) isServiceRunning(ctx context.Context, service string
 		// `nssm status` exits with code 0 if running.
 		cmd := exec.CommandContext(ctx, "nssm", "status", service)
 		err := cmd.Run()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+				return false, ErrServiceNotFound
+			}
+			return false, &CmdError{
+				Command: "nssm status",
+				Err:     err,
+			}
+		}
 		return err == nil, nil
 	} else {
 		// Use PowerShell to check the service status.
 		cmd := exec.CommandContext(ctx, "powershell", "-Command", fmt.Sprintf("(Get-Service -Name '%s').Status -eq 'Running'", service))
 		output, err := cmd.Output()
 		if err != nil {
-			// This can happen if the service is not found, in which case it's not running.
-			return false, nil
+			// If the service is not found, it's not running, and we can return ErrServiceNotFound.
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+				return false, ErrServiceNotFound
+			}
+			return false, &CmdError{
+				Command: "powershell Get-Service",
+				Output:  string(output),
+				Err:     err,
+			}
 		}
 		return strings.TrimSpace(string(output)) == "True", nil
 	}

--- a/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
+++ b/app/hydraidectl/cmd/utils/instancerunner/instancerunner_test.go
@@ -3,6 +3,7 @@ package instancerunner
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -225,17 +226,9 @@ func TestMissingService(t *testing.T) {
 		t.Fatal("Expected an error for a missing service, but got none")
 	}
 
-	// Verify the error message matches the expected format for the given OS.
-	var expectedError string
-	switch runtime.GOOS {
-	case "linux":
-		expectedError = fmt.Sprintf("service 'hydraserver-%s.service' not found", missingInstanceName)
-	case "windows":
-		expectedError = fmt.Sprintf("service 'hydraserver-%s' not found", missingInstanceName)
-	}
-
-	if err.Error() != expectedError {
-		t.Fatalf("Expected error '%s', but got '%s'", expectedError, err.Error())
+	// Check if the returned error is the expected ErrServiceNotFound
+	if !errors.Is(err, ErrServiceNotFound) {
+		t.Errorf("Expected error ErrServiceNotFound, but got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 🧩 What does this PR do?

**hydraidectl Instance Lifecycle Commands (start, stop, restart)**

This PR introduces three new critical commands to hydraidectl: start, stop, and restart. These commands provide a user-accessible, production-safe way to manage HydrAIDE instances, bridging the gap between automated orchestration and manual operational control.

---

## 🔗 Related Issue(s)

Closes #49 
Relates to #46 
Relates to #51 

---

## Technical Requirements

- Commands are implemented in cmd/start.go, cmd/stop.go, and cmd/restart.go.
- The implementation leverages StartInstance() and StopInstance() from the utils/instancerunner package.
- Input validation is performed to ensure an instance name is provided.
- Graceful shutdown is the only supported stop method; force shutdowns are explicitly rejected.
- The CLI provides clear, human-friendly output with real-time status messages.
- Exit codes are consistent: 0 for success, 1 for not found, 2 for already in desired state, and >2 for other errors.

## ✅ Checklist

- [ ] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [ ] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [ ] All new code has appropriate test coverage
- [ ] I’ve updated documentation if needed
- [ ] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [ ] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

---

## 📓 Notes for Reviewers

- Please create a service file in /etc/systemd/system in linux to use it :smile: 
- Instance runner performs everything out of the box - there isn't a need to  continuously poll the service status on the command handler, but please check the todo in stop and restart command files. This can be opened as a separate issue or can be implemented in this, I'm happy to implement it. 
