### PR TITLE
feat: Add list-instances command to Hydraidectl

### DIFF
--- a/app/hydraidectl/cmd/list.go
+++ b/app/hydraidectl/cmd/list.go
@@ -1,30 +1,87 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancedetector"
 	"github.com/spf13/cobra"
 )
 
 var listCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List all installed HydrAIDE instances",
+	Use:   "list-instances",
+	Short: "List all installed HydrAIDE instances and their status",
+	Long: `Detects and lists all HydrAIDE instances registered as OS-level services.
+		The command scans for services named 'hydraserver-<instance-name>' and reports
+		their current status on the system.`,
+
 	Run: func(cmd *cobra.Command, args []string) {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		outputFormat, _ := cmd.Flags().GetString("output")
 
-		fmt.Println("Listing hydraide instances...")
+		if !quiet {
+			fmt.Println("Scanning for HydrAIDE instances...")
+		}
 
-		// TODO: List all installed HydrAIDE instances.
-		//  To do this, we need to know what instances are currently installed.
-		//  Then determine which ones are currently running, and which ones are stopped.
-		//  (We'll need a lightweight utility that monitors processes for this.)
-		//  It's important that we can also list the *name* of each instance,
-		//  because the user will need this name to issue the `start` command.
-		//  The `ls` command should simply return the list of instances on the system,
-		//  along with their current status (e.g. running, stopped).
+		// Create a new detector for the current operating system.
+		detector, err := instancedetector.NewDetector()
+		if err != nil {
+			fmt.Printf("Failed to load instances: %v", err)
+			return
+		}
 
+		instances, err := detector.ListInstances(context.Background())
+		if err != nil {
+			fmt.Printf("Error listing instances: %v", err)
+		}
+
+		if len(instances) == 0 {
+			if !quiet {
+				fmt.Println("No HydrAIDE instances found.")
+			}
+			return
+		}
+
+		if jsonOutput || outputFormat == "json" {
+			outputJSON, err := json.MarshalIndent(instances, "", "  ")
+			if err != nil {
+				fmt.Printf("Error generating JSON output: %v", err)
+			}
+			fmt.Println(string(outputJSON))
+			return
+		}
+
+		if quiet {
+			for _, instance := range instances {
+				fmt.Println(instance.Name)
+			}
+			return
+		}
+
+		fmt.Printf("Found %d HydrAIDE instances:\n", len(instances))
+
+		// Map to detect duplicate instance names.
+		instanceMap := make(map[string]int, len(instances))
+		for _, instance := range instances {
+			instanceMap[instance.Name]++
+		}
+
+		for _, instance := range instances {
+			if instanceMap[instance.Name] > 1 {
+				fmt.Printf("- %-15s (%s)    [WARNING: Duplicate service detected]\n", instance.Name, instance.Status)
+			} else {
+				fmt.Printf("- %-15s (%s)\n", instance.Name, instance.Status)
+			}
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().BoolP("quiet", "q", false, "Return only the instance names, one per line")
+	listCmd.Flags().BoolP("json", "j", false, "Return structured output in JSON format")
+	listCmd.Flags().StringP("output", "o", "", "Output format")
 }

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
@@ -2,12 +2,11 @@ package instancedetector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
-	"strings"
 )
 
 type Instance struct {
@@ -30,77 +29,85 @@ func NewDetector() (Detector, error) {
 	}
 }
 
+// Regular expression to extract the instance name from a service unit
+// (hydraserver-<instance-name>.service).
+var reUnitName = regexp.MustCompile(`^hydraserver-(.*?)\.service$`)
+
 type linuxDetector struct {
+}
+
+// systemctlUnit is subset of fields from instance list.
+type systemctlUnit struct {
+	Name      string `json:"unit"`
+	Active    string `json:"active"`
+	Sub       string `json:"sub"`
+	LoadState string `json:"load"`
 }
 
 func (d *linuxDetector) ListInstances(ctx context.Context) ([]Instance, error) {
 
 	// List all user services, including inactive and failed ones.
-	cmd := exec.Command("systemctl", "--user", "list-units", "--type=service", "--all", "--no-legend")
-	output, err := cmd.CombinedOutput()
+	cmd := exec.CommandContext(ctx, "systemctl", "list-units", "--type=service", "--all", "--output", "json")
+	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// No instances found
+			if len(output) == 0 && exitErr.ExitCode() == 1 {
+				return []Instance{}, nil
+			}
+
 			return nil, fmt.Errorf("systemctl command failed with exit code %d: %s", exitErr.ExitCode(), string(output))
 		}
 		return nil, fmt.Errorf("failed to execute systemctl command: %v", err)
 	}
 
-	lines := strings.Split(string(output), "\n")
-
-	instancesMap := make(map[string]Instance)
-	// Regular expression to extract the instance name from a service unit (hydraserver-<instance-name>.service).
-	reUnitName := regexp.MustCompile(`^hydraserver-(.*?)\.service$`)
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		fields := strings.Fields(line)
-		if len(fields) < 4 {
-			// A valid service unit line should have at least UNIT, LOAD, ACTIVE, SUB states.
-			// hydraserver-dev.service  loaded active running <description>
-			continue
-		}
-
-		unitName := fields[0]
-		matches := reUnitName.FindStringSubmatch(unitName)
-		if len(matches) < 2 {
-			// unit name doesn't match expected service naming convention.
-			continue
-		}
-
-		instanceName := matches[1]
-		subState := fields[3]
-
-		// Normalize the systemd 'SUB' state to standard terms.
-		normalizedStatus := "unknown"
-		switch subState {
-		case "running", "active", "activating":
-			normalizedStatus = "active"
-		case "dead", "inactive", "deactivating":
-			normalizedStatus = "inactive"
-		case "failed":
-			normalizedStatus = "failed"
-		default:
-			normalizedStatus = "unknown"
-		}
-
-		// Check for duplicate instance names and discard.
-		if _, exists := instancesMap[instanceName]; exists {
-			fmt.Fprintf(os.Stderr, "Warning: Duplicate service entry found for instance '%s'. Only the first encountered status will be used.\n", instanceName)
-		} else {
-			instancesMap[instanceName] = Instance{Name: instanceName, Status: normalizedStatus}
-		}
+	units, err := parseSystemctlJSON(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse systemctl output: %w", err)
 	}
 
-	// Convert the map of unique instances back to a slice for consistent return.
 	var instances []Instance
-	for _, inst := range instancesMap {
-		instances = append(instances, inst)
+
+	for _, unit := range units {
+		match := reUnitName.FindStringSubmatch(unit.Name)
+		if len(match) < 2 || unit.LoadState != "loaded" {
+			continue
+		}
+		unitName := match[1]
+		// Normalize the systemd 'SUB' state to standard terms.
+		normalizedStatus := normalizeStatus(unit.Sub)
+
+		instances = append(instances, Instance{Name: unitName, Status: normalizedStatus})
+
 	}
+
 	return instances, nil
+}
+
+func parseSystemctlJSON(data []byte) ([]systemctlUnit, error) {
+	var units []systemctlUnit
+	if err := json.Unmarshal(data, &units); err != nil {
+		return nil, err
+	}
+	return units, nil
+}
+
+// normalizeStatus maps systemd SUB state into our high-level status.
+func normalizeStatus(sub string) string {
+	switch sub {
+	case "running":
+		return "active"
+	case "exited", "dead", "inactive":
+		return "inactive"
+	case "failed":
+		return "failed"
+	case "activating":
+		return "activating"
+	case "deactivating":
+		return "deactivating"
+	default:
+		return "unknown"
+	}
 }
 
 type windowsDetector struct {

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
@@ -15,8 +15,31 @@ type Instance struct {
 	Status string
 }
 
+// Detector is the interface for detecting and querying the status of HydrAIDE
+// application instances on a given operating system.
 type Detector interface {
+	// ListInstances returns a slice of all detected HydrAIDE instances.
+	//
+	// This method scans the system for all services that match the naming
+	// convention and returns a slice of Instance structs containing their
+	// name and normalized status. It is designed for a broad overview of
+	// all running and installed instances.
+	//
+	// It returns an empty slice and a nil error if no matching instances
+	// are found. A non-nil error is returned if the underlying system
+	// command fails to execute or its output cannot be parsed.
 	ListInstances(ctx context.Context) ([]Instance, error)
+
+	// GetInstanceStatus returns the normalized status of a single HydrAIDE instance
+	// specified by its name.
+	//
+	// This method is highly efficient as it performs a direct query for a
+	// single service, avoiding the overhead of listing all services. The
+	// returned status is one of the following: "active", "inactive",
+	// "failed", "unknown", or "not-found".
+	//
+	// It returns a non-nil error if the underlying system command fails to
+	// execute for reasons other than the service not existing.
 	GetInstanceStatus(ctx context.Context, instanceName string) (string, error)
 }
 

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector.go
@@ -1,0 +1,111 @@
+package instancedetector
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+type Instance struct {
+	Name   string
+	Status string
+}
+
+type Detector interface {
+	ListInstances(ctx context.Context) ([]Instance, error)
+}
+
+func NewDetector() (Detector, error) {
+	switch runtime.GOOS {
+	case "linux":
+		return &linuxDetector{}, nil
+	case "windows":
+		return &windowsDetector{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported operating system")
+	}
+}
+
+type linuxDetector struct {
+}
+
+func (d *linuxDetector) ListInstances(ctx context.Context) ([]Instance, error) {
+
+	// List all user services, including inactive and failed ones.
+	cmd := exec.Command("systemctl", "--user", "list-units", "--type=service", "--all", "--no-legend")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("systemctl command failed with exit code %d: %s", exitErr.ExitCode(), string(output))
+		}
+		return nil, fmt.Errorf("failed to execute systemctl command: %v", err)
+	}
+
+	lines := strings.Split(string(output), "\n")
+
+	instancesMap := make(map[string]Instance)
+	// Regular expression to extract the instance name from a service unit (hydraserver-<instance-name>.service).
+	reUnitName := regexp.MustCompile(`^hydraserver-(.*?)\.service$`)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			// A valid service unit line should have at least UNIT, LOAD, ACTIVE, SUB states.
+			// hydraserver-dev.service  loaded active running <description>
+			continue
+		}
+
+		unitName := fields[0]
+		matches := reUnitName.FindStringSubmatch(unitName)
+		if len(matches) < 2 {
+			// unit name doesn't match expected service naming convention.
+			continue
+		}
+
+		instanceName := matches[1]
+		subState := fields[3]
+
+		// Normalize the systemd 'SUB' state to standard terms.
+		normalizedStatus := "unknown"
+		switch subState {
+		case "running", "active", "activating":
+			normalizedStatus = "active"
+		case "dead", "inactive", "deactivating":
+			normalizedStatus = "inactive"
+		case "failed":
+			normalizedStatus = "failed"
+		default:
+			normalizedStatus = "unknown"
+		}
+
+		// Check for duplicate instance names and discard.
+		if _, exists := instancesMap[instanceName]; exists {
+			fmt.Fprintf(os.Stderr, "Warning: Duplicate service entry found for instance '%s'. Only the first encountered status will be used.\n", instanceName)
+		} else {
+			instancesMap[instanceName] = Instance{Name: instanceName, Status: normalizedStatus}
+		}
+	}
+
+	// Convert the map of unique instances back to a slice for consistent return.
+	var instances []Instance
+	for _, inst := range instancesMap {
+		instances = append(instances, inst)
+	}
+	return instances, nil
+}
+
+type windowsDetector struct {
+}
+
+func (d *windowsDetector) ListInstances(ctx context.Context) ([]Instance, error) {
+	return []Instance{{Name: "", Status: "Active"}}, nil
+}

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
@@ -14,9 +14,11 @@ func TestListInstances(t *testing.T) {
 	}
 
 	instances, err := detector.ListInstances(context.TODO())
-	fmt.Println(instances)
-
 	if err != nil {
 		t.Error(err)
+	}
+
+	for _, instance := range instances {
+		fmt.Println("Name: ", instance.Name, "\nStatus: ", instance.Status)
 	}
 }

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
@@ -2,23 +2,284 @@ package instancedetector
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"reflect"
 	"testing"
 )
 
-// This test does not validate the output yet. To-do: Improve tests.
-func TestListInstances(t *testing.T) {
-	detector, err := NewDetector()
-	if err != nil {
-		t.Error(err)
+// MockCommandExecutor is a test-only implementation of CommandExecutor.
+// It allows us to control the output and errors for the tests.
+type MockCommandExecutor struct {
+	output []byte
+	err    error
+}
+
+func (m *MockCommandExecutor) Execute(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return m.output, m.err
+}
+
+func TestLinuxDetector_ListInstances(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockExecutor      *MockCommandExecutor
+		expectedInstances []Instance
+		expectedErr       bool
+	}{
+		{
+			name: "Success with multiple instances",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"unit": "hydraserver-dev.service", "load": "loaded", "sub": "running"}, {"unit": "hydraserver-staging.service", "load": "loaded", "sub": "dead"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "dev", Status: "active"},
+				{Name: "staging", Status: "inactive"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Success with no matching instances",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"unit": "some-other.service", "load": "loaded", "sub": "running"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{},
+			expectedErr:       false,
+		},
+		{
+			name: "Systemctl command fails",
+			mockExecutor: &MockCommandExecutor{
+				output: nil,
+				err:    errors.New("mock command error"),
+			},
+			expectedInstances: nil,
+			expectedErr:       true,
+		},
+		{
+			name: "Invalid JSON output",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`this is not json`),
+				err:    nil,
+			},
+			expectedInstances: nil,
+			expectedErr:       true,
+		},
+		{
+			name: "Units in masked or not-found state are ignored",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"unit": "hydraserver-dev.service", "load": "loaded", "sub": "running"}, {"unit": "hydraserver-masked.service", "load": "masked", "sub": "dead"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "dev", Status: "active"},
+			},
+			expectedErr: false,
+		},
 	}
 
-	instances, err := detector.ListInstances(context.TODO())
-	if err != nil {
-		t.Error(err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			detector := &linuxDetector{executor: tc.mockExecutor}
+			instances, err := detector.ListInstances(context.Background())
 
-	for _, instance := range instances {
-		fmt.Println("Name: ", instance.Name, "\nStatus: ", instance.Status)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("Expected an error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Did not expect an error, but got: %v", err)
+			}
+
+			if !reflect.DeepEqual(instances, tc.expectedInstances) && !(len(instances) == 0 && len(tc.expectedInstances) == 0) {
+				t.Errorf("Expected instances: %+v, but got: %+v", tc.expectedInstances, instances)
+			}
+		})
 	}
 }
+
+// Test for the normalizeStatus function is still valid and doesn't need mocking.
+func TestNormalizeStatus(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"running", "active"},
+		{"exited", "inactive"},
+		{"dead", "inactive"},
+		{"inactive", "inactive"},
+		{"failed", "failed"},
+		{"activating", "activating"},
+		{"deactivating", "deactivating"},
+		{"some-other-state", "unknown"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := normalizeStatus(tc.input)
+			if result != tc.expected {
+				t.Errorf("For input %s, expected %s, but got %s", tc.input, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestWindowsDetector_ListInstances(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockExecutor      *MockCommandExecutor
+		expectedInstances []Instance
+		expectedErr       bool
+	}{
+		{
+			name: "Success with multiple instances",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"Name":"hydraserver-dev","Status":"Running"},{"Name":"hydraserver-staging","Status":"Stopped"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "dev", Status: "active"},
+				{Name: "staging", Status: "inactive"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Success with a single instance",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"Name":"hydraserver-live","Status":"StartPending"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "live", Status: "activating"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Success with no matching services",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{},
+			expectedErr:       false,
+		},
+		{
+			name: "Success with empty output (no services found)",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(``),
+				err:    nil,
+			},
+			expectedInstances: []Instance{},
+			expectedErr:       false,
+		},
+		{
+			name: "Command execution error",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(""),
+				err:    errors.New("powershell command failed"),
+			},
+			expectedInstances: nil,
+			expectedErr:       true,
+		},
+		{
+			name: "Malformed JSON output",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"Name":"hydraserver-dev"}`),
+				err:    nil,
+			},
+			expectedInstances: nil,
+			expectedErr:       true,
+		},
+		{
+			name: "Services with non-matching names are filtered",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"Name":"hydraserver-dev","Status":"Running"}, {"Name":"some-other-service","Status":"Running"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "dev", Status: "active"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Multiple status types are handled correctly",
+			mockExecutor: &MockCommandExecutor{
+				output: []byte(`[{"Name":"hydraserver-s1","Status":"Running"},{"Name":"hydraserver-s2","Status":"Stopped"},{"Name":"hydraserver-s3","Status":"Paused"},{"Name":"hydraserver-s4","Status":"StartPending"},{"Name":"hydraserver-s5","Status":"StopPending"}]`),
+				err:    nil,
+			},
+			expectedInstances: []Instance{
+				{Name: "s1", Status: "active"},
+				{Name: "s2", Status: "inactive"},
+				{Name: "s3", Status: "inactive"},
+				{Name: "s4", Status: "activating"},
+				{Name: "s5", Status: "deactivating"},
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			detector := &windowsDetector{executor: tc.mockExecutor}
+			instances, err := detector.ListInstances(context.Background())
+
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("Expected an error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Did not expect an error, but got: %v", err)
+			}
+
+			if !reflect.DeepEqual(instances, tc.expectedInstances) {
+				t.Errorf("Expected instances: %+v, but got: %+v", tc.expectedInstances, instances)
+			}
+		})
+	}
+}
+
+func TestNormalizeWindowsStatus(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"Running", "active"},
+		{"Stopped", "inactive"},
+		{"StartPending", "activating"},
+		{"StopPending", "deactivating"},
+		{"Paused", "inactive"},
+		{"UnknownStatus", "unknown"},
+		{"running", "active"},
+		{"RUNNING", "active"},
+		{"stopped", "inactive"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := normalizeWindowsStatus(tc.input)
+			if result != tc.expected {
+				t.Errorf("For input %s, expected %s, but got %s", tc.input, tc.expected, result)
+			}
+		})
+	}
+}
+
+// Integeration/E2E test.
+// func TestIntegrationListInstances(t *testing.T) {
+// 	instanceDetector, err := NewDetector()
+
+// 	if err != nil {
+// 		t.Error("Failed to get instanceDetector", err)
+// 	}
+
+// 	instances, err := instanceDetector.ListInstances(context.TODO())
+// 	if err != nil {
+// 		t.Error("List instances error: ", err)
+// 	}
+// 	fmt.Println(instances)
+// }

--- a/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
+++ b/app/hydraidectl/cmd/utils/instancedetector/instancedetector_test.go
@@ -1,0 +1,22 @@
+package instancedetector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// This test does not validate the output yet. To-do: Improve tests.
+func TestListInstances(t *testing.T) {
+	detector, err := NewDetector()
+	if err != nil {
+		t.Error(err)
+	}
+
+	instances, err := detector.ListInstances(context.TODO())
+	fmt.Println(instances)
+
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## 🧩 What does this PR do?

This PR introduces the hydraidectl list-instances command, fulfilling the requirements outlined in Issue https://github.com/hydraide/hydraide/issues/47. The new command provides a powerful way for users and scripts to discover and check the status of all installed HydrAIDE instances on a system.

**Status Reporting**: For each discovered instance, it fetches and normalizes the actual running status to a standard set of terms: active, inactive, failed, unknown, and not-found.

**Warning for Duplicates:** The output includes a warning ⚠️ [WARNING: Duplicate service detected] if multiple services reference the same instance name, a crucial detail for preventing misconfigurations.

**Quiet Mode (--quiet):** Returns only the instance names, one per line, for easy scripting.

**JSON Format (--json or --output=json):** Provides a structured JSON array for machine consumption.

---

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #47 

---

## Testing

Comprehensive unit tests have been added for both Linux and Windows detectors to validate the behavior of ListInstances and GetInstanceStatus across all expected scenarios, including successful runs, non-existent services, and command failures using Mocking command interface.

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [ ] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [x] All new code has appropriate test coverage
- [x] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers

There are additionally two status types returned when `--list-instances` is called `activating` and `deactivating` instead of `active` and `inactive` to accurately display the actual status of the instance
