### PR TITLE
feat(cli): delete lock file for destroy command

### DIFF
--- a/app/hydraidectl/cmd/utils/servicehelper/servicehelper.go
+++ b/app/hydraidectl/cmd/utils/servicehelper/servicehelper.go
@@ -458,6 +458,12 @@ func (s *serviceManagerImpl) RemoveService(instanceName string) error {
 		// Use system-level systemd commands (consistent with creation)
 		serviceFilePath := filepath.Join("/etc", "systemd", "system", fmt.Sprintf("%s.service", serviceName))
 
+		// delete lock file - in unlocked state here, since service is stopped
+		if err := deleteLockFile(instanceName); err != nil {
+			// log the error and continue
+			slog.Error("Failed to delete lock file for instance", "instanceName", instanceName)
+		}
+
 		// Stop the service if running
 		slog.Info("Stopping service", "service", serviceName)
 		cmd := exec.Command("systemctl", "stop", fmt.Sprintf("%s.service", serviceName))
@@ -499,6 +505,12 @@ func (s *serviceManagerImpl) RemoveService(instanceName string) error {
 	case WINDOWS_OS:
 		// Try to remove NSSM service first
 		slog.Info("Attempting to remove NSSM service", "service", serviceName)
+
+		// delete lock file - in unlocked state here, since service is stopped
+		if err := deleteLockFile(instanceName); err != nil {
+			// log the error and continue
+			slog.Error("Failed to delete lock file for instance", "instanceName", instanceName)
+		}
 
 		// Stop the service first
 		stopCmd := exec.Command("nssm", "stop", serviceName)
@@ -551,5 +563,23 @@ func (s *serviceManagerImpl) RemoveService(instanceName string) error {
 	default:
 		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
+	return nil
+}
+
+func deleteLockFile(instanceName string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		slog.Debug("Failed to get user home directory")
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	path := filepath.Join(home, instanceName+".lock")
+	slog.Debug("Attempting to delete lock file at", "path", path)
+
+	err = os.Remove(path)
+	if err != nil {
+		slog.Error("Failed to delete lock file.")
+		return fmt.Errorf("failed to delete lock file: %w", err)
+	}
+	slog.Debug("Successfully deleted lock file.")
 	return nil
 }

--- a/app/hydraidectl/cmd/utils/servicehelper/servicehelper_test.go
+++ b/app/hydraidectl/cmd/utils/servicehelper/servicehelper_test.go
@@ -1,0 +1,69 @@
+package servicehelper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Test suite for the deleteLockFile function.
+func Test_deleteLockFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "lock-file-test-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	os.Setenv("HOME", tempDir)
+	os.Setenv("USERPROFILE", tempDir)
+
+	t.Run("should delete an existing lock file successfully", func(t *testing.T) {
+		instanceName := "test-instance-1"
+		lockFilePath := filepath.Join(tempDir, instanceName+".lock")
+
+		// Create a dummy lock file to be deleted.
+		if _, err := os.Create(lockFilePath); err != nil {
+			t.Fatalf("failed to create dummy file: %v", err)
+		}
+
+		// Call the function under test.
+		err := deleteLockFile(instanceName)
+		if err != nil {
+			t.Errorf("expected no error, but got: %v", err)
+		}
+
+		// Verify the file no longer exists.
+		if _, err := os.Stat(lockFilePath); !os.IsNotExist(err) {
+			t.Errorf("expected file to be deleted, but it still exists or another error occurred: %v", err)
+		}
+	})
+
+	t.Run("should return error if lock file doesn't exist", func(t *testing.T) {
+		instanceName := "non-existent-file"
+
+		err := deleteLockFile(instanceName)
+		if err == nil {
+			t.Errorf("expected error but did not get any.")
+		}
+	})
+
+	t.Run("should return an error if it fails to delete due to permissions", func(t *testing.T) {
+		instanceName := "test-instance-2"
+		lockFilePath := filepath.Join(tempDir, instanceName+".lock")
+
+		if _, err := os.Create(lockFilePath); err != nil {
+			t.Fatalf("failed to create dummy file: %v", err)
+		}
+
+		if err := os.Chmod(tempDir, 0o444); err != nil {
+			t.Fatalf("failed to change directory permissions: %v", err)
+		}
+
+		err := deleteLockFile(instanceName)
+		if err == nil {
+			t.Errorf("expected an error due to permissions, but got nil")
+		}
+
+		os.Chmod(tempDir, 0o777)
+	})
+}


### PR DESCRIPTION
## 🧩 What does this PR do?
hydraidectl destroy CLI command and .hydraide/locks internal state handling

Delete the lock file in .hydraide/locks created during start/stop/restart commands

---

## 🔗 Related Issue(s)

Closes #111 

---

## ✅ Checklist

- [ ] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [ ] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [ ] All new code has appropriate test coverage
- [ ] I’ve updated documentation if needed
- [ ] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build
