### PR TITLE
feat: implement health check for instances, and add new health command

### DIFF
--- a/app/hydraidectl/cmd/health.go
+++ b/app/hydraidectl/cmd/health.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancehealth"
+	"github.com/spf13/cobra"
+)
+
+var healthInstance string
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Health of HydrAIDE instance",
+	Long: `The 'health' command connects to a specified HydrAIDE service instance
+and performs a basic health check. The command returns an exit code that can be
+used in scripts or automated pipelines to determine the instance's status.
+
+Exit codes:
+0 - The instance is healthy.
+1 - The instance is unhealthy.
+3 - An unexpected status was returned.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		healthChecker := instancehealth.NewInstanceHealth()
+		statusResponse := healthChecker.GetHealthStatus(context.Background(), healthInstance)
+
+		switch statusResponse.Status {
+		case "healthy":
+			fmt.Println("healthy")
+			os.Exit(0)
+		case "unhealthy":
+			fmt.Println("unhealthy")
+			os.Exit(1)
+		default:
+			os.Exit(3)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(healthCmd)
+
+	healthCmd.Flags().StringVarP(&healthInstance, "instance", "i", "", "Name of the service instance")
+	healthCmd.MarkFlagRequired("instance")
+}

--- a/app/hydraidectl/cmd/list.go
+++ b/app/hydraidectl/cmd/list.go
@@ -4,10 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancedetector"
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancehealth"
 	"github.com/spf13/cobra"
 )
+
+// instance struct with Json annotation
+type instance struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Health string `json:"health"`
+}
 
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -20,6 +29,7 @@ var listCmd = &cobra.Command{
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		jsonOutput, _ := cmd.Flags().GetBool("json")
 		outputFormat, _ := cmd.Flags().GetString("output")
+		noHealth, _ := cmd.Flags().GetBool("no-health")
 
 		if !quiet {
 			fmt.Println("Scanning for HydrAIDE instances...")
@@ -32,47 +42,104 @@ var listCmd = &cobra.Command{
 			return
 		}
 
-		instances, err := detector.ListInstances(context.Background())
+		ctx := context.Background()
+		instancesList, err := detector.ListInstances(ctx)
 		if err != nil {
 			fmt.Printf("Error listing instances: %v", err)
 		}
 
-		if len(instances) == 0 {
+		if len(instancesList) == 0 {
 			if !quiet {
 				fmt.Println("No HydrAIDE instances found.")
 			}
 			return
 		}
 
-		if jsonOutput || outputFormat == "json" {
-			outputJSON, err := json.MarshalIndent(instances, "", "  ")
-			if err != nil {
-				fmt.Printf("Error generating JSON output: %v", err)
+		var instancesWithHealth []instance
+		if !noHealth {
+			// Get a slice of instance names for the health checker.
+			instanceNames := make([]string, len(instancesList))
+			for i, inst := range instancesList {
+				instanceNames[i] = inst.Name
 			}
-			fmt.Println(string(outputJSON))
-			return
+
+			healthMap := getInstancesWithHealth(ctx, instanceNames)
+			for _, inst := range instancesList {
+				health, ok := healthMap[inst.Name]
+				if !ok {
+					health = "unknown"
+				}
+				instancesWithHealth = append(instancesWithHealth, instance{
+					Name:   inst.Name,
+					Status: inst.Status,
+					Health: health,
+				})
+			}
+		} else {
+			for _, inst := range instancesList {
+				instancesWithHealth = append(instancesWithHealth, instance{
+					Name:   inst.Name,
+					Status: inst.Status,
+					Health: "",
+				})
+			}
 		}
 
-		if quiet {
-			for _, instance := range instances {
-				fmt.Println(instance.Name)
+		switch {
+		case quiet:
+			for _, inst := range instancesWithHealth {
+				fmt.Println(inst.Name)
 			}
 			return
-		}
-
-		fmt.Printf("Found %d HydrAIDE instances:\n", len(instances))
-
-		// Map to detect duplicate instance names.
-		instanceMap := make(map[string]int, len(instances))
-		for _, instance := range instances {
-			instanceMap[instance.Name]++
-		}
-
-		for _, instance := range instances {
-			if instanceMap[instance.Name] > 1 {
-				fmt.Printf("- %-15s (%s)    [WARNING: Duplicate service detected]\n", instance.Name, instance.Status)
+		case jsonOutput || outputFormat == "json":
+			if noHealth {
+				// skip health
+				outputJSON, err := json.MarshalIndent(instancesList, "", "  ")
+				if err != nil {
+					fmt.Printf("Error generating JSON output: %v", err)
+				}
+				fmt.Println(string(outputJSON))
 			} else {
-				fmt.Printf("- %-15s (%s)\n", instance.Name, instance.Status)
+				outputJSON, err := json.MarshalIndent(instancesWithHealth, "", "  ")
+				if err != nil {
+					fmt.Printf("Error generating JSON output: %v", err)
+				}
+				fmt.Println(string(outputJSON))
+			}
+		default:
+			fmt.Printf("Found %d HydrAIDE instances:\n", len(instancesList))
+
+			// Map to detect duplicate instance names.
+			instanceMap := make(map[string]int, len(instancesList))
+			for _, instance := range instancesList {
+				instanceMap[instance.Name]++
+			}
+
+			const colWidth = 20
+
+			// Print headers.
+			headerFormat := fmt.Sprintf("%%-%ds %%-%ds\n", colWidth, colWidth)
+			if !noHealth {
+				headerFormat = fmt.Sprintf("%%-%ds %%-%ds %%-%ds\n", colWidth, colWidth, colWidth)
+				fmt.Printf(headerFormat, "Name", "Service Status", "Health")
+				fmt.Printf("%s\n", strings.Repeat("-", colWidth*3+2))
+			} else {
+				fmt.Printf(headerFormat, "Name", "Service Status")
+				fmt.Printf("%s\n", strings.Repeat("-", colWidth*2+1))
+			}
+
+			// Print data rows.
+			for _, inst := range instancesWithHealth {
+				warning := ""
+				if instanceMap[inst.Name] > 1 {
+					warning = "[WARNING: Duplicate service detected]"
+				}
+
+				if !noHealth {
+					fmt.Printf("%-*s %-*s %-*s %s\n", colWidth, inst.Name, colWidth, inst.Status, colWidth, inst.Health, warning)
+				} else {
+					fmt.Printf("%-*s %-*s %s\n", colWidth, inst.Name, colWidth, inst.Status, warning)
+				}
 			}
 		}
 	},
@@ -83,5 +150,28 @@ func init() {
 
 	listCmd.Flags().BoolP("quiet", "q", false, "Return only the instance names, one per line")
 	listCmd.Flags().BoolP("json", "j", false, "Return structured output in JSON format")
+	listCmd.Flags().Bool("no-health", false, "Skip health information of the instance")
 	listCmd.Flags().StringP("output", "o", "", "Output format")
+}
+
+func getInstancesWithHealth(ctx context.Context, instanceNames []string) map[string]string {
+
+	// Get healthstatus of all instances
+	healthChecker := instancehealth.NewInstanceHealth()
+	healthStatusList := healthChecker.GetListHealthStatus(ctx, instanceNames)
+
+	// flatten instance health to map name -> health
+	instanceHealthMap := make(map[string]string)
+	for _, instanceHealth := range healthStatusList {
+		switch instanceHealth.Status {
+		case "healthy":
+			instanceHealthMap[instanceHealth.InstanceName] = "healthy"
+		case "unhealthy":
+			instanceHealthMap[instanceHealth.InstanceName] = "unhealthy"
+		default:
+			instanceHealthMap[instanceHealth.InstanceName] = "unknown"
+		}
+	}
+
+	return instanceHealthMap
 }

--- a/app/hydraidectl/cmd/utils/instancehealth/instancehealth.go
+++ b/app/hydraidectl/cmd/utils/instancehealth/instancehealth.go
@@ -1,0 +1,145 @@
+package instancehealth
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/instancerunner"
+	"github.com/joho/godotenv"
+)
+
+type InstanceHealth interface {
+	GetHealthStatus(ctx context.Context, instance string) HealhStatus
+
+	GetListHealthStatus(ctx context.Context, instances []string) ([]HealhStatus, error)
+}
+
+type HealhStatus struct {
+	Instance string
+	Status   string
+	Error    error
+}
+
+// Implementation of InstanceHealth interface
+type instanceHealth struct {
+	instanceController instancerunner.InstanceController
+}
+
+func (h *instanceHealth) GetHealthStatus(ctx context.Context, instance string) HealhStatus {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	return h.performHealthCheck(ctx, instance)
+}
+
+func (h *instanceHealth) GetListHealthStatus(ctx context.Context, instances []string) ([]HealhStatus, error) {
+	return []HealhStatus{}, nil
+}
+
+func (h *instanceHealth) performHealthCheck(ctx context.Context, instance string) HealhStatus {
+	exists, err := h.instanceController.InstanceExists(ctx, instance)
+	if err != nil {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+	}
+	if !exists {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: fmt.Errorf("instance does not exist")}
+	}
+
+	workDir, err := getWorkingDirectory(instance)
+	if err != nil {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+	}
+	envPath := filepath.Join(workDir, ".env")
+	envMap, err := godotenv.Read(envPath)
+	if err != nil {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+	}
+
+	healthPortString, ok := envMap["HEALTH_CHECK_PORT"]
+	if !ok {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: fmt.Errorf("HEALTH_CHECK_PORT is missing")}
+	}
+
+	healthport, err := strconv.Atoi(healthPortString)
+	if err != nil {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+	}
+
+	url := fmt.Sprintf("http://localhost:%v/health", healthport)
+	status, err := checkHealth(ctx, url)
+
+	if err != nil {
+		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+	}
+	return HealhStatus{Instance: instance, Status: status, Error: nil}
+}
+
+func checkHealth(ctx context.Context, url string) (string, error) {
+
+	call, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(call)
+	if err != nil {
+		return "", fmt.Errorf("health check request failed: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return "unhealthy", nil
+	}
+
+	return "healthy", nil
+}
+
+func NewInstanceHealth() InstanceHealth {
+	instanceController := instancerunner.NewInstanceController()
+
+	return &instanceHealth{instanceController: instanceController}
+}
+
+func getWorkingDirectory(instance string) (string, error) {
+	serviceDir := filepath.Join("/etc", "systemd", "system")
+	serviceFile := fmt.Sprintf("hydraserver-%s.service", instance)
+	fullPath := filepath.Join(serviceDir, serviceFile)
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip comments and empty lines
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		// Check for the "WorkingDirectory" key
+		if strings.HasPrefix(line, "WorkingDirectory=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1]), nil
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error while scanning file: %w", err)
+	}
+
+	return "", nil
+}

--- a/app/hydraidectl/cmd/utils/instancehealth/instancehealth.go
+++ b/app/hydraidectl/cmd/utils/instancehealth/instancehealth.go
@@ -54,9 +54,9 @@ type InstanceHealth interface {
 
 // HealhStatus represents the outcome of a health check for a single instance.
 type HealhStatus struct {
-	Instance string
-	Status   string
-	Error    error
+	InstanceName string
+	Status       string
+	Error        error
 }
 
 // Implementation of InstanceHealth interface
@@ -113,39 +113,39 @@ func (h *instanceHealth) GetListHealthStatus(ctx context.Context, instances []st
 func (h *instanceHealth) performHealthCheck(ctx context.Context, instance string) HealhStatus {
 	exists, err := h.instanceController.InstanceExists(ctx, instance)
 	if err != nil {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: err}
 	}
 	if !exists {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: fmt.Errorf("instance does not exist")}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: fmt.Errorf("instance does not exist")}
 	}
 
 	workDir, err := getWorkingDirectory(instance)
 	if err != nil {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: err}
 	}
 	envPath := filepath.Join(workDir, ".env")
 	envMap, err := godotenv.Read(envPath)
 	if err != nil {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: err}
 	}
 
 	healthPortString, ok := envMap["HEALTH_CHECK_PORT"]
 	if !ok {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: fmt.Errorf("HEALTH_CHECK_PORT is missing")}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: fmt.Errorf("HEALTH_CHECK_PORT is missing")}
 	}
 
 	healthport, err := strconv.Atoi(healthPortString)
 	if err != nil {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: err}
 	}
 
 	url := fmt.Sprintf("http://localhost:%v/health", healthport)
 	status, err := checkHealth(ctx, url)
 
 	if err != nil {
-		return HealhStatus{Instance: instance, Status: "unknown", Error: err}
+		return HealhStatus{InstanceName: instance, Status: "unknown", Error: err}
 	}
-	return HealhStatus{Instance: instance, Status: status, Error: nil}
+	return HealhStatus{InstanceName: instance, Status: status, Error: nil}
 }
 
 // checkHealth performs a low-level HTTP GET request to a URL.

--- a/app/hydraidectl/cmd/utils/instancehealth/instancehealth_test.go
+++ b/app/hydraidectl/cmd/utils/instancehealth/instancehealth_test.go
@@ -1,0 +1,82 @@
+package instancehealth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCheckHealth(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	t.Run("successful 200 OK", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		status, err := checkHealth(ctx, ts.URL)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if status != "healthy" {
+			t.Fatalf("Expected status 'healthy', got: '%s'", status)
+		}
+	})
+
+	t.Run("unhealthy 404 Not Found", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		status, err := checkHealth(ctx, ts.URL)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if status != "unhealthy" {
+			t.Fatalf("Expected status 'unhealthy', got: '%s'", status)
+		}
+	})
+
+	t.Run("unhealthy 500 Internal Server Error", func(t *testing.T) {
+		// Create a mock server that returns 500
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		status, err := checkHealth(ctx, ts.URL)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if status != "unhealthy" {
+			t.Fatalf("Expected status 'unhealthy', got: '%s'", status)
+		}
+	})
+
+	t.Run("network request fails", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		ts.Close()
+
+		status, err := checkHealth(ctx, ts.URL)
+		if err == nil {
+			t.Fatalf("Expected an error, got none.")
+		}
+		if status != "" {
+			t.Fatalf("Expected an empty status, got: '%s'", status)
+		}
+	})
+}
+
+// Can be used as integration test - create a instance and replace the instance parameter.
+// func TestGetStatus(t *testing.T) {
+// 	instance := NewInstanceHealth()
+// 	status := instance.GetHealthStatus(context.TODO(), "new-health")
+// 	if status.Error != nil {
+// 		t.Errorf("expected some status without error, got error %s", status.Error)
+// 	}
+// }

--- a/docs/hydraidectl/hydraidectl-install.md
+++ b/docs/hydraidectl/hydraidectl-install.md
@@ -90,4 +90,3 @@ You can now manage your HydrAIDE instances with `hydraidectl`.
 For details, see the [HydrAIDECtl User Manual](hydraidectl-user-manual.md).
 
 ---
-

--- a/docs/hydraidectl/hydraidectl-install.md
+++ b/docs/hydraidectl/hydraidectl-install.md
@@ -72,4 +72,22 @@ It will download and replace the previous version automatically.
 
 ---
 
-For more CLI usage, see the full `hydraidectl` documentation.
+### 📖 Next Steps
+
+You can now manage your HydrAIDE instances with `hydraidectl`.  
+
+## Available Commands
+
+* [`init`](hydraidectl-user-manual.md#init--interactive-setup-wizard) – Initialize a new HydrAIDE instance interactively
+* [`service`](hydraidectl-user-manual.md#service--set-up-persistent-system-service) – Create and manage a persistent system service
+* [`start`](hydraidectl-user-manual.md#start--start-an-instance) – Start a specific HydrAIDE instance
+* [`stop`](hydraidectl-user-manual.md#stop--stop-a-running-instance) – Gracefully stop an instance
+* [`restart`](hydraidectl-user-manual.md#restart--restart-instance) – Restart a running or stopped instance
+* [`list`](hydraidectl-user-manual.md#list--show-all-instances) – Show all registered HydrAIDE instances on the host
+* [`health`](hydraidectl-user-manual.md#health--instance-health) – Display health of an instance
+* [`destroy`](hydraidectl-user-manual.md#destroy--remove-instance) – Fully delete an instance, optionally including all its data
+
+For details, see the [HydrAIDECtl User Manual](hydraidectl-user-manual.md).
+
+---
+


### PR DESCRIPTION
## 🧩 What does this PR do?

This PR introduces a new hydraidectl health command and integrates a health-checking mechanism into hydraidectl list.

**New hydraidectl health --instance <name> command:** This command performs a lightweight HTTP GET request to the instance's configured health endpoint. It returns exit code 0 on healthy (200 OK) and a non-zero exit code on unhealthy (non-200, timeout, or connection error). The command's output is a simple healthy or unhealthy string.

**Integration into hydraidectl list:** The list command now concurrently runs the same health probe for each instance, displaying the result in a new Health column. The status can be healthy, unhealthy, or unknown (if the probe times out or the configuration is missing).

**New Flags:**

- `--no-health`: Skips the health check for faster output.

- `--json`: Includes a "health": "healthy|unhealthy|unknown" field in the JSON output.

- `--quiet`: Remains unchanged, printing only instance names.

**Documentation**: The documentation has been updated to reflect these changes, including a new health command section, expanded output examples for list, and new sections for Command Synopsis, Environment Variables, and Exit Codes.

---
- hydraidectl health --instance dev prints `healthy` on a 200 OK response and `unhealthy` on errors, returning the correct exit codes.

- hydraidectl list shows a Health column for every instance with the correct status (`healthy/unhealthy/unknown`).

- hydraidectl list --json output includes a "`health`" field.

- The hydraidectl-user-manual.md file is updated with full documentation, examples, and cross-linking to the install guide.

- Unit tests cover env parsing, HTTP status mapping, list rendering, and integration tests with a mock server.

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #122 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [x] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [x] All new code has appropriate test coverage
- [x] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [x] docs
- [ ] ci/build

## 📓 Notes for Reviewers

The implementation only covers Linux system, and the same should work for wsl in windows
