### PR TITLE
chore: 114 feature hydraidectl cert command to generate standalone certificates

### DIFF
--- a/app/hydraidectl/cmd/cert.go
+++ b/app/hydraidectl/cmd/cert.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/certificate"
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/filesystem"
+	"github.com/spf13/cobra"
+)
+
+// certCmd defines a CLI subcommand that ONLY generates TLS certificates
+// without modifying or reinitializing any running instances/containers.
+// Useful when you need to (re)issue certs separately from the full init flow.
+var certCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "Generate certificates only, without modifying instances",
+	Long: `This command generates all required certificate files for a Docker container,
+or replaces certificates for an existing instance without re-initializing it.
+Do NOT use this during a fresh installation — the 'init' command already includes
+certificate generation steps.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		// Reader for interactive stdin prompts
+		reader := bufio.NewReader(os.Stdin)
+
+		// Filesystem helper (abstracted for testability and consistency)
+		fs := filesystem.New()
+
+		// Ask for the destination folder where the generated cert files will be placed
+		fmt.Println("\n📁 Certificate folder")
+		fmt.Println("Please provide the directory where you want to place the certificate files.")
+		fmt.Println("Make sure the directory exists and is writable.")
+		fmt.Print("Your certificate folder path: ")
+		certFolder, _ := reader.ReadString('\n')
+		certFolder = strings.TrimSpace(certFolder)
+
+		// Launch interactive certificate prompts (CN, SANs, etc.)
+		certPrompts := certificate.NewPrompts()
+		certPrompts.Start(reader)
+
+		// Print a concise summary before proceeding
+		fmt.Println("\n🔧 Configuration Summary:")
+		fmt.Println("  • CN:         ", certPrompts.GetCN())
+		fmt.Println("  • DNS SANs:   ", strings.Join(certPrompts.GetDNS(), ", "))
+		fmt.Println("  • IP SANs:    ", strings.Join(certPrompts.GetIP(), ", "))
+
+		// Final confirmation (default: no)
+		fmt.Print("\n✅ Proceed with certificate generation? (y/n) [default: n]: ")
+		confirm, _ := reader.ReadString('\n')
+		confirm = strings.ToLower(strings.TrimSpace(confirm))
+		if confirm != "y" && confirm != "yes" {
+			fmt.Println("🚫 Generation cancelled.")
+			return
+		}
+
+		fmt.Println("\n✅ Starting certificate generation...")
+
+		ctx := context.Background()
+
+		// Validate that target directory exists
+		exists, err := fs.CheckIfDirExists(ctx, certFolder)
+		if err != nil {
+			fmt.Printf("❌ Error checking directory %s: %v\n", certFolder, err)
+			return
+		}
+		if !exists {
+			fmt.Printf("❌ Directory does not exist: %s\n", certFolder)
+			return
+		}
+
+		// Generate the certificate/key material to temporary/local files
+		certPrompts.GenerateCert()
+
+		// Move generated files to the target directory
+		fmt.Println("\n📂 Moving TLS certificates to the certificate directory...")
+
+		for _, file := range certPrompts.GetCertificateFiles() {
+			destPath := filepath.Join(certFolder, filepath.Base(file))
+			fmt.Printf("  • Moving %s to %s\n", file, destPath)
+			if err := fs.MoveFile(ctx, file, destPath); err != nil {
+				fmt.Println("❌ Error moving certificate file:", err)
+				return
+			}
+			fmt.Printf("✅ Moved %s to %s\n", file, destPath)
+		}
+
+		fmt.Println("✅ TLS certificates moved successfully.")
+	},
+}
+
+func init() {
+	// Register the 'cert' subcommand under the root command
+	rootCmd.AddCommand(certCmd)
+}

--- a/app/hydraidectl/cmd/init.go
+++ b/app/hydraidectl/cmd/init.go
@@ -439,32 +439,12 @@ This command guides you through the process of creating a new HydrAIDE instance,
 			fmt.Printf("✅ Directory exists: %s\n", fullPath)
 		}
 
-		// Generate the TLS certificate
-		fmt.Println("\n🔒 Generating TLS certificate...")
-		certGen := certificate.New(certPrompts.GetCN(), certPrompts.GetDNS(), certPrompts.GetIP())
-		if err := certGen.Generate(); err != nil {
-			fmt.Println("❌ Error generating TLS certificate:", err)
-			return
-		}
-		fmt.Println("✅ TLS certificate generated successfully.")
-
-		var certFiles []string
-		caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY := certGen.Files()
-		certFiles = []string{caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY}
-
-		fmt.Println("\n📄 TLS Certificate Files:")
-		fmt.Println("  • CA CRT:     ", caCRT)
-		fmt.Println("  • CA KEY:     ", caKEY)
-		fmt.Println("  • Server CRT: ", serverCRT)
-		fmt.Println("  • Server KEY: ", serverKEY)
-		fmt.Println("  • Client CRT: ", clientCRT)
-		fmt.Println("  • Client KEY: ", clientKEY)
-
+		certPrompts.GenerateCert()
 		// Copy the server and client TLS certificates to the certificate directory
 		fmt.Println("\n📂 Copying TLS certificates to the certificate directory...")
 
 		// move all certFiles to the certificate directory
-		for _, file := range certFiles {
+		for _, file := range certPrompts.GetCertificateFiles() {
 			destPath := filepath.Join(envCfg.HydraideBasePath, "certificate", filepath.Base(file))
 			fmt.Printf("  • Moving %s to %s\n", file, destPath)
 			if err := fs.MoveFile(ctx, file, destPath); err != nil {

--- a/app/hydraidectl/cmd/root.go
+++ b/app/hydraidectl/cmd/root.go
@@ -27,6 +27,7 @@ Try:
   hydraidectl stop
   hydraidectl destroy
   hydraidectl list
+  hydraidectl cert
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()


### PR DESCRIPTION
This pull request introduces a new `cert` subcommand to the `hydraidectl` CLI for generating TLS certificates independently of instance initialization, and refactors certificate prompting and generation logic for better code reuse and maintainability. The most important changes are grouped below:

**New Certificate Command and Documentation:**

* Added a new `cert` subcommand (`certCmd` in `cert.go`) that interactively generates TLS certificates and places them in a specified folder, without modifying or reinitializing any HydrAIDE instances. This is useful for certificate renewal or Docker deployments.
* Updated the CLI help (`root.go`) and user manual (`hydraidectl-user-manual.md`) to document the new `cert` command, including its usage, workflow, and which certificate files to distribute to clients/servers. [[1]](diffhunk://#diff-205333a58be8853c9f1c9c0eb409d65c36b49255fd4f1da2d685339a0601f0caR30) [[2]](diffhunk://#diff-247500c8709a9a892f8350fba3580e2d27257aab5266eced9b3e6fcea3f25ab4R31) [[3]](diffhunk://#diff-247500c8709a9a892f8350fba3580e2d27257aab5266eced9b3e6fcea3f25ab4R394-R452)

**Certificate Prompting and Generation Refactor:**

* Introduced a reusable `Prompts` interface and implementation in `certificate/prompt.go` to handle all interactive certificate parameter collection (CN, DNS, IPs) and certificate file management. This logic is now shared between `init` and `cert` commands, reducing duplication and improving maintainability.
* Refactored the `init` command (`init.go`) to use the new `Prompts` abstraction for certificate collection and generation, replacing the previous inline logic and removing the now-unneeded `CertConfig` struct. [[1]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL22-L27) [[2]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL80-R81) [[3]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL367-R312) [[4]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL498-R447)

**User Experience Improvements:**

* Both `init` and `cert` commands now provide a clear summary of certificate configuration before generation, and display detailed output about generated files and their destinations. [[1]](diffhunk://#diff-fdd31333957dfb81230aa1547bbe929c0b28d254d916bff5ea89894344801c77R1-R99) [[2]](diffhunk://#diff-d96218031d860c45ca8c370b880ba8a464b3059eef93a46375525fb37bcceabfR1-R164) [[3]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL367-R312)

These changes make certificate management more modular, user-friendly, and suitable for a wider range of deployment scenarios.


## 🔗 Related Issue(s)

Closes #114 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [x] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [] All new code has appropriate test coverage
- [x] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers

<!-- Any special review notes, instructions, or context goes here -->
