### PR TITLE
chore: Feature/hydraidectl

### DIFF
--- a/app/hydraidectl/cmd/cert.go
+++ b/app/hydraidectl/cmd/cert.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/certificate"
+	"github.com/hydraide/hydraide/app/hydraidectl/cmd/utils/filesystem"
+	"github.com/spf13/cobra"
+)
+
+// certCmd defines a CLI subcommand that ONLY generates TLS certificates
+// without modifying or reinitializing any running instances/containers.
+// Useful when you need to (re)issue certs separately from the full init flow.
+var certCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "Generate certificates only, without modifying instances",
+	Long: `This command generates all required certificate files for a Docker container,
+or replaces certificates for an existing instance without re-initializing it.
+Do NOT use this during a fresh installation — the 'init' command already includes
+certificate generation steps.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		// Reader for interactive stdin prompts
+		reader := bufio.NewReader(os.Stdin)
+
+		// Filesystem helper (abstracted for testability and consistency)
+		fs := filesystem.New()
+
+		// Ask for the destination folder where the generated cert files will be placed
+		fmt.Println("\n📁 Certificate folder")
+		fmt.Println("Please provide the directory where you want to place the certificate files.")
+		fmt.Println("Make sure the directory exists and is writable.")
+		fmt.Print("Your certificate folder path: ")
+		certFolder, _ := reader.ReadString('\n')
+		certFolder = strings.TrimSpace(certFolder)
+
+		// Launch interactive certificate prompts (CN, SANs, etc.)
+		certPrompts := certificate.NewPrompts()
+		certPrompts.Start(reader)
+
+		// Print a concise summary before proceeding
+		fmt.Println("\n🔧 Configuration Summary:")
+		fmt.Println("  • CN:         ", certPrompts.GetCN())
+		fmt.Println("  • DNS SANs:   ", strings.Join(certPrompts.GetDNS(), ", "))
+		fmt.Println("  • IP SANs:    ", strings.Join(certPrompts.GetIP(), ", "))
+
+		// Final confirmation (default: no)
+		fmt.Print("\n✅ Proceed with certificate generation? (y/n) [default: n]: ")
+		confirm, _ := reader.ReadString('\n')
+		confirm = strings.ToLower(strings.TrimSpace(confirm))
+		if confirm != "y" && confirm != "yes" {
+			fmt.Println("🚫 Generation cancelled.")
+			return
+		}
+
+		fmt.Println("\n✅ Starting certificate generation...")
+
+		ctx := context.Background()
+
+		// Validate that target directory exists
+		exists, err := fs.CheckIfDirExists(ctx, certFolder)
+		if err != nil {
+			fmt.Printf("❌ Error checking directory %s: %v\n", certFolder, err)
+			return
+		}
+		if !exists {
+			fmt.Printf("❌ Directory does not exist: %s\n", certFolder)
+			return
+		}
+
+		// Generate the certificate/key material to temporary/local files
+		certPrompts.GenerateCert()
+
+		// Move generated files to the target directory
+		fmt.Println("\n📂 Moving TLS certificates to the certificate directory...")
+
+		for _, file := range certPrompts.GetCertificateFiles() {
+			destPath := filepath.Join(certFolder, filepath.Base(file))
+			fmt.Printf("  • Moving %s to %s\n", file, destPath)
+			if err := fs.MoveFile(ctx, file, destPath); err != nil {
+				fmt.Println("❌ Error moving certificate file:", err)
+				return
+			}
+			fmt.Printf("✅ Moved %s to %s\n", file, destPath)
+		}
+
+		fmt.Println("✅ TLS certificates moved successfully.")
+	},
+}
+
+func init() {
+	// Register the 'cert' subcommand under the root command
+	rootCmd.AddCommand(certCmd)
+}

--- a/app/hydraidectl/cmd/init.go
+++ b/app/hydraidectl/cmd/init.go
@@ -19,12 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type CertConfig struct {
-	CN  string
-	DNS []string
-	IP  []string
-}
-
 type EnvConfig struct {
 	LogLevel               string
 	LogTimeFormat          string
@@ -77,65 +71,14 @@ This command guides you through the process of creating a new HydrAIDE instance,
 
 		fmt.Printf("\n🚀 Starting HydrAIDE setup for instance: \"%s\"\n\n", instanceName)
 
-		var cert CertConfig
 		var envCfg EnvConfig
 
 		validator := validator.New()
 		ctx := context.Background()
 
-		// Certificate CN – default = localhost
-		fmt.Println("🌐 TLS Certificate Setup")
-		fmt.Println("🔖 Common Name (CN) is the main name assigned to the certificate.")
-		fmt.Println("It usually identifies your company or internal system.")
-		fmt.Print("CN (e.g. yourcompany, api.hydraide.local) [default: hydraide]: ")
-		cnInput, _ := reader.ReadString('\n')
-		cert.CN = strings.TrimSpace(cnInput)
-		if cert.CN == "" {
-			cert.CN = "hydraide"
-		}
-
-		// Add localhost
-		cert.DNS = append(cert.DNS, "localhost")
-		cert.IP = append(cert.IP, "127.0.0.1")
-
-		// Additional IP addresses
-		fmt.Println("\n🌐 Add additional IP addresses to the certificate?")
-		fmt.Println("By default, '127.0.0.1' is included for localhost access.")
-		fmt.Println()
-		fmt.Println("Now, list any other IP addresses where clients will access the HydrAIDE server.")
-		fmt.Println("For example, if the HydrAIDE container is reachable at 192.168.106.100:4900, include that IP.")
-		fmt.Println("These IPs must match the address used in the TLS connection, or it will fail.")
-		fmt.Print("Do you want to add other IPs besides 127.0.0.1? (y/n) [default: n]: ")
-
-		ans, _ := reader.ReadString('\n')
-		if strings.ToLower(strings.TrimSpace(ans)) == "y" {
-			fmt.Print("Enter IPs (comma-separated, e.g. 192.168.1.5,10.0.0.12): ")
-			ipInput, _ := reader.ReadString('\n')
-			ips := strings.Split(strings.TrimSpace(ipInput), ",")
-			for _, ip := range ips {
-				ip = strings.TrimSpace(ip)
-				if ip != "" {
-					cert.IP = append(cert.IP, ip)
-				}
-			}
-		}
-
-		fmt.Println("\n🌐 Will clients connect via a domain name (FQDN)?")
-		fmt.Println("This includes public domains (e.g. api.example.com) or internal DNS (e.g. hydraide.lan).")
-		fmt.Println("To ensure secure TLS connections, you must list any domains that clients will use.")
-		fmt.Print("Add domain names to the certificate? (y/n) [default: n]: ")
-		ans, _ = reader.ReadString('\n')
-		if strings.ToLower(strings.TrimSpace(ans)) == "y" {
-			fmt.Print("Enter domain names (comma-separated, e.g. api.example.com,hydraide.local): ")
-			dnsInput, _ := reader.ReadString('\n')
-			domains := strings.Split(strings.TrimSpace(dnsInput), ",")
-			for _, d := range domains {
-				d = strings.TrimSpace(d)
-				if d != "" {
-					cert.DNS = append(cert.DNS, d)
-				}
-			}
-		}
+		// start the certificate prompting
+		certPrompts := certificate.NewPrompts()
+		certPrompts.Start(reader)
 
 		fmt.Println("\n🔌 Port Configuration")
 		fmt.Println("This is the port where the HydrAIDE binary server will listen for client connections.")
@@ -364,9 +307,9 @@ This command guides you through the process of creating a new HydrAIDE instance,
 		// CONFIGURATION SUMMARY
 		fmt.Println("\n🔧 Configuration Summary:")
 		fmt.Println("=== NETWORK ===")
-		fmt.Println("  • CN:         ", cert.CN)
-		fmt.Println("  • DNS SANs:   ", strings.Join(cert.DNS, ", "))
-		fmt.Println("  • IP SANs:    ", strings.Join(cert.IP, ", "))
+		fmt.Println("  • CN:         ", certPrompts.GetCN())
+		fmt.Println("  • DNS SANs:   ", strings.Join(certPrompts.GetDNS(), ", "))
+		fmt.Println("  • IP SANs:    ", strings.Join(certPrompts.GetIP(), ", "))
 		fmt.Println("  • Main Port:  ", envCfg.HydraidePort)
 		fmt.Println("  • Health Port:", envCfg.HealthCheckPort)
 
@@ -435,6 +378,7 @@ This command guides you through the process of creating a new HydrAIDE instance,
 				fmt.Printf("✅ Created directory: %s\n", folder)
 			}
 		} else {
+
 			// All folders exist, warn about potential data loss
 			fmt.Println("\n⚠️ WARNING: All required folders already exist:", strings.Join(folders, ", "))
 			fmt.Println("🚨 Continuing may DELETE ALL EXISTING DATA in these folders!")
@@ -495,32 +439,12 @@ This command guides you through the process of creating a new HydrAIDE instance,
 			fmt.Printf("✅ Directory exists: %s\n", fullPath)
 		}
 
-		// Generate the TLS certificate
-		fmt.Println("\n🔒 Generating TLS certificate...")
-		certGen := certificate.New(cert.CN, cert.DNS, cert.IP)
-		if err := certGen.Generate(); err != nil {
-			fmt.Println("❌ Error generating TLS certificate:", err)
-			return
-		}
-		fmt.Println("✅ TLS certificate generated successfully.")
-
-		var certFiles []string
-		caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY := certGen.Files()
-		certFiles = []string{caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY}
-
-		fmt.Println("\n📄 TLS Certificate Files:")
-		fmt.Println("  • CA CRT:     ", caCRT)
-		fmt.Println("  • CA KEY:     ", caKEY)
-		fmt.Println("  • Server CRT: ", serverCRT)
-		fmt.Println("  • Server KEY: ", serverKEY)
-		fmt.Println("  • Client CRT: ", clientCRT)
-		fmt.Println("  • Client KEY: ", clientKEY)
-
+		certPrompts.GenerateCert()
 		// Copy the server and client TLS certificates to the certificate directory
 		fmt.Println("\n📂 Copying TLS certificates to the certificate directory...")
 
 		// move all certFiles to the certificate directory
-		for _, file := range certFiles {
+		for _, file := range certPrompts.GetCertificateFiles() {
 			destPath := filepath.Join(envCfg.HydraideBasePath, "certificate", filepath.Base(file))
 			fmt.Printf("  • Moving %s to %s\n", file, destPath)
 			if err := fs.MoveFile(ctx, file, destPath); err != nil {

--- a/app/hydraidectl/cmd/root.go
+++ b/app/hydraidectl/cmd/root.go
@@ -27,6 +27,7 @@ Try:
   hydraidectl stop
   hydraidectl destroy
   hydraidectl list
+  hydraidectl cert
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()

--- a/app/hydraidectl/cmd/utils/certificate/prompt.go
+++ b/app/hydraidectl/cmd/utils/certificate/prompt.go
@@ -1,0 +1,164 @@
+package certificate
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+// Prompts defines the interface for collecting TLS certificate parameters
+// interactively from the user.
+//
+// ✅ Use this when:
+// - You need to generate a self-signed TLS certificate for HydrAIDE
+// - You want to prompt for Common Name (CN), IP addresses, and domain names
+//
+// Typical flow:
+//  1. Call NewPrompts() to create an empty prompt handler
+//  2. Call Start(reader) with a *bufio.Reader (e.g. os.Stdin)
+//  3. Retrieve the collected values via GetCN(), GetIP(), GetDNS()
+type Prompts interface {
+	Start(reader *bufio.Reader)
+	GetCN() string
+	GetDNS() []string
+	GetIP() []string
+	GenerateCert()
+	GetCertificateFiles() []string
+}
+
+// prompts is the concrete implementation of Prompts.
+// It stores the Common Name (CN), DNS names, and IP addresses
+// that will be embedded into the certificate’s Subject Alternative Name (SAN).
+type prompts struct {
+	CN               string
+	DNS              []string
+	IP               []string
+	certificateFiles []string
+}
+
+// NewPrompts creates and returns a new Prompts instance
+// with default, empty values.
+//
+// Example:
+//
+//	p := certificate.NewPrompts()
+//	p.Start(bufio.NewReader(os.Stdin))
+func NewPrompts() Prompts {
+	return &prompts{
+		CN:               "",
+		DNS:              []string{},
+		IP:               []string{},
+		certificateFiles: []string{},
+	}
+}
+
+// Start launches the interactive prompt sequence to collect
+// certificate configuration details from the user.
+//
+// 🧭 Steps:
+//  1. Ask for the Common Name (CN) → defaults to "hydraide"
+//  2. Automatically include "localhost" (DNS) and "127.0.0.1" (IP)
+//  3. Optionally add more IP addresses
+//  4. Optionally add fully qualified domain names (FQDNs)
+//
+// These inputs determine the certificate’s Subject Alternative Names (SANs).
+// TLS clients must connect using one of these values for validation to succeed.
+func (p *prompts) Start(reader *bufio.Reader) {
+	// Common Name (CN)
+	fmt.Println("\n🌐 TLS Certificate Setup")
+	fmt.Println("🔖 Common Name (CN) is the main name assigned to the certificate.")
+	fmt.Println("It usually identifies your company or internal system.")
+	fmt.Print("CN (e.g. yourcompany, api.hydraide.local) [default: hydraide]: ")
+	cnInput, _ := reader.ReadString('\n')
+	p.CN = strings.TrimSpace(cnInput)
+	if p.CN == "" {
+		p.CN = "hydraide"
+	}
+
+	// Always include localhost
+	p.DNS = append(p.DNS, "localhost")
+	p.IP = append(p.IP, "127.0.0.1")
+
+	// Additional IP addresses
+	fmt.Println("\n🌐 Add additional IP addresses to the certificate?")
+	fmt.Println("By default, '127.0.0.1' is included for localhost access.")
+	fmt.Println("Now, list any other IP addresses where clients will access the HydrAIDE server.")
+	fmt.Println("These IPs must match the address used in the TLS connection, or it will fail.")
+	fmt.Print("Do you want to add other IPs besides 127.0.0.1? (y/n) [default: n]: ")
+
+	ans, _ := reader.ReadString('\n')
+	if strings.ToLower(strings.TrimSpace(ans)) == "y" {
+		fmt.Print("Enter IPs (comma-separated, e.g. 192.168.1.5,10.0.0.12): ")
+		ipInput, _ := reader.ReadString('\n')
+		ips := strings.Split(strings.TrimSpace(ipInput), ",")
+		for _, ip := range ips {
+			ip = strings.TrimSpace(ip)
+			if ip != "" {
+				p.IP = append(p.IP, ip)
+			}
+		}
+	}
+
+	// Domain names (FQDNs)
+	fmt.Println("\n🌐 Will clients connect via a domain name (FQDN)?")
+	fmt.Println("This includes public domains (e.g. api.example.com) or internal DNS (e.g. hydraide.lan).")
+	fmt.Print("Add domain names to the certificate? (y/n) [default: n]: ")
+	ans, _ = reader.ReadString('\n')
+	if strings.ToLower(strings.TrimSpace(ans)) == "y" {
+		fmt.Print("Enter domain names (comma-separated, e.g. api.example.com,hydraide.local): ")
+		dnsInput, _ := reader.ReadString('\n')
+		domains := strings.Split(strings.TrimSpace(dnsInput), ",")
+		for _, d := range domains {
+			d = strings.TrimSpace(d)
+			if d != "" {
+				p.DNS = append(p.DNS, d)
+			}
+		}
+	}
+}
+
+// GenerateCert creates the TLS certificate using the collected parameters.
+func (p *prompts) GenerateCert() {
+
+	// Generate the TLS certificate
+	fmt.Println("\n🔒 Generating TLS certificate...")
+	certGen := New(p.CN, p.DNS, p.IP)
+	if err := certGen.Generate(); err != nil {
+		fmt.Println("❌ Error generating TLS certificate:", err)
+		return
+	}
+	fmt.Println("✅ TLS certificate generated successfully.")
+
+	caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY := certGen.Files()
+	p.certificateFiles = []string{caCRT, caKEY, serverCRT, serverKEY, clientCRT, clientKEY}
+
+	fmt.Println("\n📄 TLS Certificate Files:")
+	fmt.Println("  • CA CRT:     ", caCRT)
+	fmt.Println("  • CA KEY:     ", caKEY)
+	fmt.Println("  • Server CRT: ", serverCRT)
+	fmt.Println("  • Server KEY: ", serverKEY)
+	fmt.Println("  • Client CRT: ", clientCRT)
+	fmt.Println("  • Client KEY: ", clientKEY)
+
+}
+
+// GetCertificateFiles returns the list of generated certificate files.
+func (p *prompts) GetCertificateFiles() []string {
+	// Returns the list of generated certificate files
+	return p.certificateFiles
+}
+
+// GetCN returns the Common Name (CN) provided by the user or the default.
+func (p *prompts) GetCN() string {
+	return p.CN
+}
+
+// GetDNS returns all DNS names collected for SAN.
+func (p *prompts) GetDNS() []string {
+	return p.DNS
+}
+
+// GetIP returns all IP addresses collected for SAN.
+func (p *prompts) GetIP() []string {
+	return p.IP
+}


### PR DESCRIPTION
This pull request introduces a new `cert` subcommand to the `hydraidectl` CLI, enabling users to generate TLS certificates independently of the main instance initialization process. It also refactors certificate prompting and generation logic for improved code reuse and maintainability. Documentation and help text are updated to reflect the new command and workflow.

**Key changes:**

### New Feature: Certificate Generation Command

* Adds a new `cert` subcommand (`app/hydraidectl/cmd/cert.go`) that interactively generates TLS certificates and places them in a user-specified directory, without modifying or reinitializing any HydrAIDE instances. This is particularly useful for Docker deployments or certificate rotation.

### Certificate Prompting Refactor

* Extracts and centralizes the interactive certificate prompting logic into a new `Prompts` interface and implementation (`app/hydraidectl/cmd/utils/certificate/prompt.go`). This logic is now reused by both the `init` and `cert` commands, reducing duplication and improving maintainability.
* Updates the `init` command (`app/hydraidectl/cmd/init.go`) to use the new certificate prompting abstraction, removing the old inline logic and the `CertConfig` struct. Certificate generation and file handling in `init` are now delegated to the new prompt interface. [[1]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL22-L27) [[2]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL80-R81) [[3]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL367-R312) [[4]](diffhunk://#diff-78439a8d5a2baa70f7b241ed4da81c1c2c44070b70faf12a009d2a8806af921dL498-R447)

### Documentation and CLI Help Updates

* Updates the CLI help output and user manual to document the new `cert` command, including usage instructions, explanation of generated files, and guidance on when to use it. [[1]](diffhunk://#diff-205333a58be8853c9f1c9c0eb409d65c36b49255fd4f1da2d685339a0601f0caR30) [[2]](diffhunk://#diff-247500c8709a9a892f8350fba3580e2d27257aab5266eced9b3e6fcea3f25ab4R31) [[3]](diffhunk://#diff-247500c8709a9a892f8350fba3580e2d27257aab5266eced9b3e6fcea3f25ab4R394-R452)

### Minor Improvements

* Minor formatting and warning message improvements in the `init` command for better user experience.
