### PR TITLE
feat: Clarify IsSwampExist error handling and add ErrorShuttingDown s…

### DIFF
--- a/app/server/e2etests/e2etests_test.go
+++ b/app/server/e2etests/e2etests_test.go
@@ -104,10 +104,12 @@ func createGrpcClient() {
 	// create a new gRPC client object
 	servers := []*client.Server{
 		{
-			Host:         os.Getenv("HYDRA_TEST_SERVER"),
-			FromIsland:   0,
-			ToIsland:     100,
-			CertFilePath: os.Getenv("HYDRA_CERT"),
+			Host:          os.Getenv("HYDRAIDE_TEST_SERVER"),
+			FromIsland:    0,
+			ToIsland:      100,
+			CACrtPath:     os.Getenv("HYDRAIDE_CA_CRT"),
+			ClientCrtPath: os.Getenv("HYDRAIDE_CLIENT_CRT"),
+			ClientKeyPath: os.Getenv("HYDRAIDE_CLIENT_KEY"),
 		},
 	}
 

--- a/app/server/gateway/gateway.go
+++ b/app/server/gateway/gateway.go
@@ -745,6 +745,17 @@ func (g Gateway) IsSwampExist(_ context.Context, in *hydrapb.IsSwampExistRequest
 
 	_, err := checkSwampName(g.ZeusInterface, in.GetIslandID(), in.SwampName, true)
 	if err != nil {
+		if s, ok := status.FromError(err); ok {
+			switch s.Code() {
+			// The swamp does not exist, but this is not an error in this case
+			case codes.FailedPrecondition:
+				return &hydrapb.IsSwampExistResponse{
+					IsExist: false,
+				}, nil
+			}
+		}
+
+		// there is an error with the swamp name
 		return &hydrapb.IsSwampExistResponse{
 			IsExist: false,
 		}, err


### PR DESCRIPTION
…upport

## 🧩 What does this PR do?

This pull request introduces improved error handling for server shutdown scenarios in the `hydraidego` SDK, updates environment variable usage for test server configuration, and adds a new test for the `IsSwampExist` method. The main focus is on making the SDK more robust by explicitly handling the case when the HydrAIDE server is shutting down and ensuring consistent test setup.

**Error handling improvements:**

* Added explicit handling for the `codes.Aborted` gRPC error code throughout the SDK methods (e.g., `IsSwampExist`, `IsKeyExists`, `CatalogCreate`, `CatalogUpdate`, `ProfileSave`, etc.), returning a new `ErrorShuttingDown` error when the HydrAIDE server is shutting down. This includes defining a new error code and message for this scenario. [[1]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R35) [[2]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R687-R689) [[3]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18L694-R700) [[4]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R757-R759) [[5]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R880-R882) [[6]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R996-R998) [[7]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R1152-R1154) [[8]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R1412-R1414) [[9]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R1512-R1514) [[10]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R1850-R1852) [[11]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R1944-R1946) [[12]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2085-R2087) [[13]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2192-R2194) [[14]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2287-R2289) [[15]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2353-R2355) [[16]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2428-R2430) [[17]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2557-R2559) [[18]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R2610-R2612) [[19]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R5423-R5425) [[20]](diffhunk://#diff-c334cb4f6850d98b85d40de3a9d924c884c625e9c7c9e0748141135566868b18R5482)

* Updated the documentation and comments to clarify the SDK's behavior when the swamp name is nil or when the swamp does not exist, and to document the new error handling path.

**Test and configuration updates:**

* Updated the test server configuration in both the Go SDK and e2e tests to use new environment variables (`HYDRAIDE_TEST_SERVER`, `HYDRAIDE_CA_CRT`, `HYDRAIDE_CLIENT_CRT`, `HYDRAIDE_CLIENT_KEY`) for consistency and clarity. [[1]](diffhunk://#diff-0e5af5c2f09e03d5ea0b6e49bdad42b6b6eb0136b192dfca336b5db67f8a1756L107-R112) [[2]](diffhunk://#diff-a731850c96ac9d524ff76e6fc7776f9e294369fe793e74b191b106a0dc27a502L34-R39)
* Added a new unit test for the `IsSwampExist` method, verifying its behavior before and after creating a swamp.

**Gateway logic improvement:**

* Improved the gateway's `IsSwampExist` method to treat `codes.FailedPrecondition` as a non-error case (swamp does not exist), aligning server and SDK behaviors.

---

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #153 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [x] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [x] All new code has appropriate test coverage
- [x] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [x] server
- [ ] core
- [ ] hydraidectl
- [x] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build
