### PR TITLE
fix(cli): gracefully handle hydraidectl update on fresh installs. Fix…

### DIFF
--- a/app/hydraidectl/cmd/update.go
+++ b/app/hydraidectl/cmd/update.go
@@ -42,6 +42,18 @@ var updateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// Check if any instances exist
+		instances, err := metaInterface.GetAllInstances()
+		if err != nil {
+			fmt.Printf("Error while retrieving instances: %v\n", err)
+			os.Exit(1)
+		}
+		if len(instances) == 0 {
+			fmt.Println("No HydrAIDE instances found.")
+			fmt.Println("Use 'hydraidectl init' to create and initialize an instance before running update.")
+			return
+		}
+
 		// Load instance metadata
 		instanceMeta, err := metaInterface.GetInstance(updateInstance)
 		if err != nil {

--- a/app/hydraidectl/cmd/utils/buildmetadata/Instance.go
+++ b/app/hydraidectl/cmd/utils/buildmetadata/Instance.go
@@ -106,6 +106,13 @@ func New(fs filesystem.FileSystem) (MetadataStore, error) {
 		}
 	}
 
+	// if the metadata file does not exist, create it
+	if _, err := fs.Stat(ctx, configFilePath); os.IsNotExist(err) {
+		if err := fs.WriteFile(ctx, configFilePath, []byte("{}"), 0640); err != nil {
+			return nil, fmt.Errorf("failed to create metadata file: %w", err)
+		}
+	}
+
 	return &storeImpl{
 		fs:             fs,
 		configFilePath: configFilePath,


### PR DESCRIPTION

## 🧩 What does this PR do?

Fixes the `hydraidectl update` command to handle the case when no HydrAIDE instances exist yet.  
Instead of failing with a missing `metadata.json` file error, it now gracefully detects that no instances are initialized and prints a friendly message guiding the user to run `hydraidectl init` first.

---

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #160 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [ ] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [ ] All new code has appropriate test coverage
- [ ] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers

- Tested on a fresh install with no instances; the CLI now prints a clear message instead of failing.
- Tried different ways to handle missing metadata, but creating an empty `metadata.json` file proved to be the simplest and safest fix.
- No changes to existing instance update logic.
