### PR TITLE
fix(cli): suggest correct command for a non-existent instance. Fixes …

### DIFF
--- a/app/hydraidectl/cmd/restart.go
+++ b/app/hydraidectl/cmd/restart.go
@@ -93,7 +93,7 @@ and then configured as a service with 'service'.`,
 				printJsonRestart(fmt.Errorf("instance '%s' does not exist", restartInstance))
 				return
 			}
-			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", restartInstance)
 			os.Exit(1)
 		}
 
@@ -112,7 +112,7 @@ and then configured as a service with 'service'.`,
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", restartInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", restartInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceNotRunning):

--- a/app/hydraidectl/cmd/start.go
+++ b/app/hydraidectl/cmd/start.go
@@ -88,7 +88,7 @@ If the instance is already running, the command does nothing.`,
 				printJsonStart(fmt.Errorf("instance '%s' not found", startInstance))
 				return
 			}
-			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", startInstance)
 			os.Exit(1)
 		}
 
@@ -102,7 +102,7 @@ If the instance is already running, the command does nothing.`,
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", startInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", startInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceAlreadyRunning):

--- a/app/hydraidectl/cmd/stop.go
+++ b/app/hydraidectl/cmd/stop.go
@@ -92,7 +92,7 @@ If the instance is not running, the command does nothing.`,
 				printJsonStop(fmt.Errorf("instance '%s' does not exist", stopInstance))
 				return
 			}
-			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
+			fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", stopInstance)
 			os.Exit(1)
 		}
 
@@ -111,7 +111,7 @@ If the instance is not running, the command does nothing.`,
 		if err != nil {
 			switch {
 			case errors.Is(err, instancerunner.ErrServiceNotFound):
-				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list-instances` to see available instances.\n", stopInstance)
+				fmt.Printf("❌ Instance \"%s\" not found.\nUse `hydraidectl list` to see available instances.\n", stopInstance)
 				os.Exit(1)
 
 			case errors.Is(err, instancerunner.ErrServiceNotRunning):


### PR DESCRIPTION
…#161

## 🧩 What does this PR do?

Fixes the CLI error message in hydraidectl start when a non-existent instance is provided.
The previous message suggested using hydraidectl list-instances, which is incorrect.
Now it correctly recommends hydraidectl list to view available instances.

---

## 🔗 Related Issue(s)

<!-- Link any related issues here (e.g., closes #123) -->
Closes #161 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style
- [ ] pre-commit.ci passed or I ran `pre-commit run --all-files`
- [x] All new code has appropriate test coverage
- [ ] I’ve updated documentation if needed
- [x] No large files or secrets committed

---

## 🗂️ Scope of Change

- [ ] server
- [ ] core
- [x] hydraidectl
- [ ] sdk/go
- [ ] sdk/python
- [ ] docs
- [ ] ci/build

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers

<!-- Any special review notes, instructions, or context goes here -->
