### PR TITLE
172 feature support hydraideomitempty in catalog models

### DIFF
--- a/docs/sdk/go/examples/models/model_catalog_example.go
+++ b/docs/sdk/go/examples/models/model_catalog_example.go
@@ -10,6 +10,22 @@ import "time"
 // This struct demonstrates how to define a model for CatalogCreate.
 // Each field uses `hydraide` tags to indicate its role within the KeyValuePair.
 // All values will be transformed into HydrAIDE-compatible binary format at runtime.
+//
+// !!! Important Note about `omitempty`:
+// In Catalog models, just like in Profile models, **all fields except the key** may include
+// the `hydraide:"...,omitempty"` decorator.
+// - If `omitempty` is present and the field has a zero/empty value, HydrAIDE will completely ignore it.
+// - This means:
+//   - It won’t be uploaded or stored at all,
+//   - It won’t be validated,
+//   - It won’t consume space in memory or on disk.
+// - Typical use: metadata fields like `updatedAt`, `updatedBy` should be omitted when creating a new record
+//   (since at that point only `createdAt` / `createdBy` make sense).
+// - Later updates can fill them when relevant.
+//
+// Example:
+//   UpdatedAt time.Time `hydraide:"updatedAt,omitempty"`
+//   → if zero, it is not stored in HydrAIDE until explicitly set.
 
 type CatalogCreditLog struct {
 	// 🔑 REQUIRED
@@ -68,13 +84,13 @@ type CatalogCreditLog struct {
 	//   ExpireAt: time.Now().UTC().Add(10 * time.Minute)
 	//
 	// If omitted or zero, this Treasure is considered non-expirable.
-	ExpireAt time.Time `hydraide:"expireAt"`
+	ExpireAt time.Time `hydraide:"expireAt,omitempty"`
 
 	// 🧾 OPTIONAL METADATA — useful for tracking/audit purposes
 	// If omitted, these fields will not be included in the stored record.
 
-	CreatedBy string    `hydraide:"createdBy"` // Who created the record
-	CreatedAt time.Time `hydraide:"createdAt"` // When it was created
-	UpdatedBy string    `hydraide:"updatedBy"` // Who last updated it
-	UpdatedAt time.Time `hydraide:"updatedAt"` // When it was last updated
+	CreatedBy string    `hydraide:"createdBy,omitempty"` // Who created the record
+	CreatedAt time.Time `hydraide:"createdAt,omitempty"` // When it was created
+	UpdatedBy string    `hydraide:"updatedBy,omitempty"` // Who last updated it
+	UpdatedAt time.Time `hydraide:"updatedAt,omitempty"` // When it was last updated
 }

--- a/docs/sdk/go/go-sdk.md
+++ b/docs/sdk/go/go-sdk.md
@@ -285,11 +285,28 @@ This model fits best when you need to:
 * 🧩 Can use metadata decorators: `createdBy`, `createdAt`, `updatedBy`, `updatedAt`
 * 🧪 Index-based read operations with configurable order & limit
 * 🧠 Ideal for structured slices, trees, or versioned record lists
-  🔄 Fully reactive: supports real-time streaming via Subscribe()
+* 🔄 Fully reactive: supports real-time streaming via Subscribe()
+* 🆕 Supports `omitempty` decorator for all fields except the `key`
 
-> 💡 Catalog Swamps are the most reactive data structures in HydrAIDE.
-> They are the primary targets for Subscribe() operations, making it easy to listen to individual keys (Treasure-level events), filtered value changes, or full Swamp activity.
-> This makes Catalogs ideal for building live dashboards, notification systems, audit pipelines, and streaming analytics.
+#### 🆕 About `omitempty`
+
+In Catalog Swamps, every field **except the key** can use the `omitempty` decorator in its `hydraide` tag.  
+
+* If a field is tagged with `omitempty` and its value is empty/zero/nil:
+  * It will **not** be uploaded to HydrAIDE,
+  * It will **not** be validated,
+  * It will **not** be stored in memory or on disk.  
+* This is especially useful for metadata fields like `updatedAt` and `updatedBy`, which should remain absent when creating a new record.  
+* Later, when updates occur, these fields can be set and will then be stored normally.
+
+👉 Example:
+
+```go
+UpdatedBy string    `hydraide:"updatedBy,omitempty"`
+UpdatedAt time.Time `hydraide:"updatedAt,omitempty"`
+````
+
+If these fields are empty during initial creation, they will simply not exist in HydrAIDE.
 
 #### 📌 Common Use Cases
 
@@ -310,6 +327,8 @@ user := &CatalogModelUser{
 	},
 	CreatedBy: "auth-service",
 	CreatedAt: time.Now(),
+	UpdatedBy: "",                 // will be ignored, due to omitempty
+	UpdatedAt: time.Time{},        // will be ignored, due to omitempty
 }
 
 _ = user.Save(repo) // Upserts the record
@@ -322,6 +341,9 @@ This stores a Treasure in:
 ```
 
 HydrAIDE will track when and who wrote the data, and can later stream or react to changes over time.
+Because of `omitempty`, `UpdatedBy` and `UpdatedAt` are not stored until they actually hold values.
+
+--- 
 
 #### 🔎 Indexed Reads
 

--- a/sdk/go/hydraidego/hydraidego_test.go
+++ b/sdk/go/hydraidego/hydraidego_test.go
@@ -41,7 +41,7 @@ func setup() {
 
 	servers := []*client.Server{server}
 	clientInterface = client.New(servers, 1000, 104857600)
-	if err := clientInterface.Connect(true); err != nil {
+	if err := clientInterface.Connect(false); err != nil {
 		slog.Error("Failed to connect to Hydraide server", "error", err)
 		os.Exit(1) // exit if the connection fails
 	} else {
@@ -65,6 +65,278 @@ func teardown() {
 func TestHydraidego_Heartbeat(t *testing.T) {
 	err := hydraidegoInterface.Heartbeat(context.Background())
 	assert.NoError(t, err, "Heartbeat should not return an error")
+}
+
+func TestConvertCatalogModelWithOmitEmpty(t *testing.T) {
+	// Get current time for non-empty time values
+	now := time.Now().UTC()
+
+	testCases := []struct {
+		name           string
+		input          interface{}
+		expectedKey    string
+		expectedValues map[string]bool // Fields that should be set in the result
+	}{
+		{
+			name: "basic key-value without omitempty",
+			input: &struct {
+				Key   string `hydraide:"key"`
+				Value string `hydraide:"value"`
+			}{"test-key", "test-value"},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"stringVal": true,
+			},
+		},
+		{
+			name: "value with omitempty - non-empty",
+			input: &struct {
+				Key   string `hydraide:"key"`
+				Value string `hydraide:"value,omitempty"`
+			}{"test-key", "test-value"},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"stringVal": true,
+			},
+		},
+		{
+			name: "value with omitempty - empty string",
+			input: &struct {
+				Key   string `hydraide:"key"`
+				Value string `hydraide:"value,omitempty"`
+			}{"test-key", ""},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal": true, // All fields omitted, VoidVal should be true
+			},
+		},
+		{
+			name: "all metadata fields - non-empty",
+			input: &struct {
+				Key       string    `hydraide:"key"`
+				Value     int       `hydraide:"value"`
+				ExpireAt  time.Time `hydraide:"expireAt"`
+				CreatedAt time.Time `hydraide:"createdAt"`
+				CreatedBy string    `hydraide:"createdBy"`
+				UpdatedAt time.Time `hydraide:"updatedAt"`
+				UpdatedBy string    `hydraide:"updatedBy"`
+			}{
+				"test-key", 123, now, now, "user1", now, "user2",
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"int64Val":  true,
+				"expiredAt": true,
+				"createdAt": true,
+				"createdBy": true,
+				"updatedAt": true,
+				"updatedBy": true,
+			},
+		},
+		{
+			name: "all metadata fields - are omitempty - non-empty",
+			input: &struct {
+				Key       string    `hydraide:"key"`
+				Value     int       `hydraide:"value,omitempty"`
+				ExpireAt  time.Time `hydraide:"expireAt,omitempty"`
+				CreatedAt time.Time `hydraide:"createdAt,omitempty"`
+				CreatedBy string    `hydraide:"createdBy,omitempty"`
+				UpdatedAt time.Time `hydraide:"updatedAt,omitempty"`
+				UpdatedBy string    `hydraide:"updatedBy,omitempty"`
+			}{
+				"test-key", 123, now, now, "user1", now, "user2",
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"int64Val":  true,
+				"expiredAt": true,
+				"createdAt": true,
+				"createdBy": true,
+				"updatedAt": true,
+				"updatedBy": true,
+			},
+		},
+		{
+			name: "metadata fields with omitempty - empty",
+			input: &struct {
+				Key       string    `hydraide:"key"`
+				Value     int       `hydraide:"value"`
+				ExpireAt  time.Time `hydraide:"expireAt,omitempty"`
+				CreatedAt time.Time `hydraide:"createdAt,omitempty"`
+				CreatedBy string    `hydraide:"createdBy,omitempty"`
+				UpdatedAt time.Time `hydraide:"updatedAt,omitempty"`
+				UpdatedBy string    `hydraide:"updatedBy,omitempty"`
+			}{
+				"test-key", 123, time.Time{}, time.Time{}, "", time.Time{}, "",
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"int64Val":  true,
+				"expiredAt": false,
+				"createdAt": false,
+				"createdBy": false,
+				"updatedAt": false,
+				"updatedBy": false,
+			},
+		},
+		{
+			name: "mixed empty and non-empty with omitempty",
+			input: &struct {
+				Key       string    `hydraide:"key"`
+				Value     int       `hydraide:"value"`
+				ExpireAt  time.Time `hydraide:"expireAt,omitempty"`
+				CreatedAt time.Time `hydraide:"createdAt,omitempty"`
+				CreatedBy string    `hydraide:"createdBy,omitempty"`
+				UpdatedAt time.Time `hydraide:"updatedAt"`           // No omitempty
+				UpdatedBy string    `hydraide:"updatedBy,omitempty"` // With omitempty
+			}{
+				"test-key", 123, time.Time{}, now, "user1", now, "",
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"int64Val":  true,
+				"expiredAt": false, // Should be omitted (empty with omitempty)
+				"createdAt": true,  // Should be included (non-empty)
+				"createdBy": true,  // Should be included (non-empty)
+				"updatedAt": true,  // Should be included (no omitempty tag)
+				"updatedBy": false, // Should be omitted (empty with omitempty)
+			},
+		},
+		{
+			name: "pointer values with omitempty",
+			input: &struct {
+				Key    string  `hydraide:"key"`
+				Value  *string `hydraide:"value,omitempty"`
+				IntPtr *int    `hydraide:"createdBy,omitempty"` // Repurposing field for testing
+			}{
+				"test-key", nil, nil,
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   true,  // All fields omitted, VoidVal should be true
+				"stringVal": false, // Should be omitted (nil with omitempty)
+				"createdBy": false, // Should be omitted (nil with omitempty)
+			},
+		},
+		{
+			name: "slice and map with omitempty",
+			input: &struct {
+				Key      string         `hydraide:"key"`
+				Value    []int          `hydraide:"value,omitempty"`
+				MapField map[string]int `hydraide:"createdBy,omitempty"` // Repurposing field
+			}{
+				"test-key", []int{}, map[string]int{},
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   true,  // All fields omitted, VoidVal should be true
+				"bytesVal":  false, // Should be omitted (empty slice with omitempty)
+				"createdBy": false, // Should be omitted (empty map with omitempty)
+			},
+		},
+		{
+			name: "non-empty slice",
+			input: &struct {
+				Key       string `hydraide:"key"`
+				Value     []int  `hydraide:"value,omitempty"`
+				CreatedBy string `hydraide:"createdBy,omitempty"` // Repurposing field
+			}{
+				"test-key", []int{1, 2, 3}, "admin",
+			},
+			expectedKey: "test-key",
+			expectedValues: map[string]bool{
+				"voidVal":   false, // Not all fields omitted, VoidVal should be false
+				"bytesVal":  true,  // Should be included (non-empty slice with omitempty)
+				"createdBy": true,  // Should be included (non-empty map with omitempty)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Convert to key-value pair
+			kv, err := convertCatalogModelToKeyValuePair(tc.input)
+
+			require.NoError(t, err, "Conversion should succeed")
+
+			// Check key
+			assert.Equal(t, tc.expectedKey, kv.Key, "Key should match expected value")
+
+			if tc.expectedValues == nil {
+				assert.True(t, *kv.VoidVal, "All fields should be omitted, VoidVal should be true")
+			} else {
+
+				for field, expected := range tc.expectedValues {
+					switch field {
+					case "voidVal":
+						if expected {
+							assert.True(t, *kv.VoidVal, "voidVal should be set to true")
+						} else {
+							assert.Nil(t, kv.VoidVal, "voidVal should be set to false")
+						}
+					case "stringVal":
+						if expected {
+							assert.NotEmpty(t, kv.StringVal, "stringVal should be set")
+						} else {
+							assert.Empty(t, kv.StringVal, "stringVal should be empty")
+						}
+					case "int64Val":
+						if expected {
+							assert.NotZero(t, kv.Int64Val, "int64Val should be set")
+						} else {
+							assert.Zero(t, kv.Int64Val, "int64Val should be zero")
+						}
+					case "expiredAt":
+						if expected {
+							assert.False(t, kv.ExpiredAt.AsTime().IsZero(), "expiredAt should be set")
+						} else {
+							assert.Nil(t, kv.ExpiredAt, "expiredAt should be nil")
+						}
+					case "createdAt":
+						if expected {
+							assert.False(t, kv.CreatedAt.AsTime().IsZero(), "createdAt should be set")
+						} else {
+							assert.Nil(t, kv.CreatedAt, "createdAt should be nil")
+						}
+					case "createdBy":
+						if expected {
+							assert.NotEmpty(t, kv.CreatedBy, "createdBy should be set")
+						} else {
+							assert.Empty(t, kv.CreatedBy, "createdBy should be empty")
+						}
+					case "updatedAt":
+						if expected {
+							assert.False(t, kv.UpdatedAt.AsTime().IsZero(), "updatedAt should be set")
+						} else {
+							assert.Nil(t, kv.UpdatedAt, "updatedAt should be nil")
+						}
+					case "updatedBy":
+						if expected {
+							assert.NotEmpty(t, kv.UpdatedBy, "updatedBy should be set")
+						} else {
+							assert.Empty(t, kv.UpdatedBy, "updatedBy should be empty")
+						}
+					case "bytesVal":
+						if expected {
+							assert.NotEmpty(t, kv.BytesVal, "bytesVal should be set")
+						} else {
+							assert.Empty(t, kv.BytesVal, "bytesVal should be empty")
+						}
+					}
+
+				}
+			}
+
+		})
+	}
+
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## 🧩 What does this PR do?

This PR adds support for `hydraide:"omitempty"` on **Catalog models** (previously only supported for Profiles).  
Now every field except the `key` can be tagged with `omitempty`.  
When set, HydrAIDE will **completely ignore** the field if it has a zero/empty value — it won’t be uploaded, validated, or stored.  

This enables cleaner model definitions and avoids redundant metadata (e.g., `updatedAt`, `updatedBy` at creation time).  
A full test suite has been added to verify the behavior.

---

## 🔗 Related Issue(s)

Closes #172 

---

## ✅ Checklist

- [x] Follows [Conventional Commit](https://www.conventionalcommits.org/) style  
- [x] pre-commit.ci passed or I ran `pre-commit run --all-files`  
- [x] All new code has appropriate test coverage  
- [x] I’ve updated documentation (catalog model examples, docs)  
- [x] No large files or secrets committed  

---

## 🗂️ Scope of Change

- [ ] server  
- [ ] core  
- [ ] hydraidectl  
- [x] sdk/go  
- [ ] sdk/python  
- [x] docs  
- [ ] ci/build  

---

## 📓 Notes for Reviewers

- Focus on changes in `convertCatalogModelToKeyValuePair()` to ensure consistent handling of `omitempty` in Catalogs.  
- Tests cover both presence and absence of metadata fields.  
- Please verify that no regression occurs in Profile-related logic, since Profile already supported `omitempty`.

