### PR TITLE
feat: Handle pretty json print for destroy command

### DIFF
--- a/app/hydraidectl/cmd/destroy.go
+++ b/app/hydraidectl/cmd/destroy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -16,8 +17,9 @@ import (
 )
 
 var (
-	destroyInstance string
-	purgeData       bool
+	destroyInstance        string
+	confirmDestroyInstance string
+	purgeData              bool
 )
 
 var destroyCmd = &cobra.Command{
@@ -33,33 +35,66 @@ var destroyCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 		defer cancel()
 
+		printJson, _ := cmd.Flags().GetBool("json")
+		forceDestroy, _ := cmd.Flags().GetBool("force")
+
+		jsonResponse := NewJsonDestroyInfo(destroyInstance)
+
+		if !forceDestroy && confirmDestroyInstance != "" && confirmDestroyInstance != destroyInstance {
+			if printJson {
+				printDestroyJson(UpdateJsonDestroyInfo(jsonResponse, WithErrorMessage("Instance name confirmation failed")))
+			} else {
+				fmt.Println("❌ Instance name confirmation failed")
+			}
+			os.Exit(1)
+		}
+
 		fs := filesystem.New()
 		bm, err := buildmeta.New(fs)
 		if err != nil {
-			fmt.Println("❌ Failed to initialize metadata store:", err)
+			if printJson {
+				printDestroyJson(UpdateJsonDestroyInfo(jsonResponse, WithErrorMessage(err.Error())))
+			} else {
+				fmt.Println("❌ Failed to initialize metadata store:", err)
+			}
 			os.Exit(1)
 		}
 
 		instanceController := instancerunner.NewInstanceController()
 		serviceManager := servicehelper.New()
 
-		fmt.Printf("🔥 Initializing destruction for instance: \"%s\"\n", destroyInstance)
-
-		fmt.Println("🔄 Checking instance status...")
+		if !printJson {
+			fmt.Printf("🔥 Initializing destruction for instance: \"%s\"\n", destroyInstance)
+			fmt.Println("🔄 Checking instance status...")
+		}
 		err = instanceController.StopInstance(ctx, destroyInstance)
 		if err != nil && err != instancerunner.ErrServiceNotRunning && err != instancerunner.ErrServiceNotFound {
-			fmt.Printf("❌ Could not stop instance '%s': %v\n", destroyInstance, err)
-			fmt.Println("🚫 Aborting destroy operation. Please stop the service manually before proceeding.")
+			if printJson {
+				printDestroyJson(UpdateJsonDestroyInfo(jsonResponse, WithErrorMessage(err.Error()), WithWarning("Could not stop instance")))
+			} else {
+				fmt.Printf("❌ Could not stop instance '%s': %v\n", destroyInstance, err)
+				fmt.Println("🚫 Aborting destroy operation. Please stop the service manually before proceeding.")
+			}
 			os.Exit(1)
 		}
-		fmt.Println("✅ Instance is stopped or was not running.")
+		if !printJson {
+			fmt.Println("✅ Instance is stopped or was not running.")
+			fmt.Println("🗑️  Removing service definition...")
+		}
 
-		fmt.Println("🗑️  Removing service definition...")
 		if err := serviceManager.RemoveService(destroyInstance); err != nil {
-			fmt.Printf("⚠️  Could not remove service definition: %v\n", err)
-			fmt.Println("   You may need to remove it manually. Continuing...")
+			if !printJson {
+				fmt.Printf("⚠️  Could not remove service definition: %v\n", err)
+				fmt.Println("   You may need to remove it manually. Continuing...")
+			} else {
+				UpdateJsonDestroyInfo(jsonResponse, WithServiceStopped())
+			}
 		} else {
-			fmt.Println("✅ Service definition removed.")
+			if !printJson {
+				fmt.Println("✅ Service definition removed.")
+			} else {
+				UpdateJsonDestroyInfo(jsonResponse, WithServiceRemoved(), WithServiceStopped())
+			}
 		}
 
 		// FIXED: Added delay to prevent console output overlap.
@@ -67,50 +102,77 @@ var destroyCmd = &cobra.Command{
 
 		instanceData, metaErr := bm.GetInstance(destroyInstance)
 		if metaErr != nil {
-			fmt.Printf("⚠️  Could not find metadata for instance '%s'. Cannot purge data.\n", destroyInstance)
-			fmt.Printf("✅ Destruction of service '%s' complete.\n", destroyInstance)
+			if printJson {
+				printDestroyJson(UpdateJsonDestroyInfo(jsonResponse, WithStatus("partial"), WithWarning("Could not find metadata")))
+			} else {
+				fmt.Printf("⚠️  Could not find metadata for instance '%s'. Cannot purge data.\n", destroyInstance)
+				fmt.Printf("✅ Destruction of service '%s' complete.\n", destroyInstance)
+			}
 			os.Exit(0)
 		}
 		basePath := instanceData.BasePath
 
+		UpdateJsonDestroyInfo(jsonResponse, WithBasePath(basePath))
+
 		if purgeData {
-			fmt.Println("\n====================================================================")
-			fmt.Println("‼️ DANGER: FULL DATA PURGE INITIATED ‼️")
-			fmt.Printf("⚠️ You are about to permanently delete the entire base path for instance '%s'.\n", destroyInstance)
-			fmt.Printf("   Directory to be deleted: %s\n", basePath)
-			fmt.Println("   This includes all data, certificates, logs, and the binary.")
-			fmt.Println("   This operation is IRREVERSIBLE.")
-			fmt.Println("====================================================================")
-			fmt.Printf("\n👉 To confirm, type the full instance name ('%s'): ", destroyInstance)
+			if !printJson && !forceDestroy && confirmDestroyInstance == "" {
+				fmt.Println("\n====================================================================")
+				fmt.Println("‼️ DANGER: FULL DATA PURGE INITIATED ‼️")
+				fmt.Printf("⚠️ You are about to permanently delete the entire base path for instance '%s'.\n", destroyInstance)
+				fmt.Printf("   Directory to be deleted: %s\n", basePath)
+				fmt.Println("   This includes all data, certificates, logs, and the binary.")
+				fmt.Println("   This operation is IRREVERSIBLE.")
+				fmt.Println("====================================================================")
+				fmt.Printf("\n👉 To confirm, type the full instance name ('%s'): ", destroyInstance)
 
-			reader := bufio.NewReader(os.Stdin)
-			input, _ := reader.ReadString('\n')
-			if strings.TrimSpace(input) != destroyInstance {
-				fmt.Println("🚫 Input did not match. Data purge aborted.")
-				os.Exit(0)
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				if strings.TrimSpace(input) != destroyInstance {
+					fmt.Println("🚫 Input did not match. Data purge aborted.")
+					os.Exit(0)
+				}
+
+				fmt.Println("✅ Confirmation received. Proceeding with base path deletion.")
 			}
-
-			fmt.Println("✅ Confirmation received. Proceeding with base path deletion.")
 
 			// FIXED: Use the robust fs.RemoveDir which wraps os.RemoveAll.
 			if err := fs.RemoveDir(ctx, basePath); err != nil {
-				fmt.Printf("❌ An error occurred during deletion: %v\n", err)
-				fmt.Println("   Please check file permissions and try again.")
+				if printJson {
+					printDestroyJson(UpdateJsonDestroyInfo(jsonResponse, WithErrorMessage("An error occurred during deletion:"+err.Error())))
+				} else {
+					fmt.Printf("❌ An error occurred during deletion: %v\n", err)
+					fmt.Println("   Please check file permissions and try again.")
+				}
 				os.Exit(1)
 			}
-			fmt.Printf("✅ Base path '%s' deleted successfully.\n", basePath)
-		} else {
+			if !printJson {
+				fmt.Printf("✅ Base path '%s' deleted successfully.\n", basePath)
+			} else {
+				UpdateJsonDestroyInfo(jsonResponse, WithPurged())
+			}
+		} else if !printJson {
 			fmt.Println("\nℹ️  --purge flag not specified. The service was removed, but all data remains.")
 			fmt.Printf("   Data directory: %s\n", basePath)
 		}
 
 		// CHANGED: Clean up the instance from the metadata file.
 		if err := bm.DeleteInstance(destroyInstance); err != nil {
-			fmt.Printf("⚠️  Could not remove instance metadata: %v\n", err)
+			if !printJson {
+				fmt.Printf("⚠️  Could not remove instance metadata: %v\n", err)
+			}
 		} else {
-			fmt.Println("✅ Instance metadata cleaned up.")
+			if printJson {
+				UpdateJsonDestroyInfo(jsonResponse, WithMetaDataRemoved())
+			} else {
+				fmt.Println("✅ Instance metadata cleaned up.")
+			}
 		}
-		fmt.Printf("\n✅ Destruction of instance '%s' complete.\n", destroyInstance)
+		if printJson {
+			printDestroyJson(jsonResponse)
+		} else {
+			fmt.Printf("\n✅ Destruction of instance '%s' complete.\n", destroyInstance)
+		}
+		os.Exit(0)
 	},
 }
 
@@ -118,9 +180,103 @@ func init() {
 	rootCmd.AddCommand(destroyCmd)
 	destroyCmd.Flags().StringVarP(&destroyInstance, "instance", "i", "", "Name of the HydrAIDE instance to destroy (required)")
 	destroyCmd.Flags().BoolVar(&purgeData, "purge", false, "Permanently delete the entire base path for the instance")
+	destroyCmd.Flags().BoolP("json", "j", false, "Return structured output in JSON format")
+	destroyCmd.Flags().StringVarP(&confirmDestroyInstance, "confirm-name", "c", "", "Confirmation of the HydrAIDE instance to destroy")
+	destroyCmd.Flags().BoolP("force", "f", false, "Force destroy instance, skipping the instance name confirmation")
+
 	if err := destroyCmd.MarkFlagRequired("instance"); err != nil {
 		fmt.Println("❌ Error marking 'instance' flag as required:", err)
 		os.Exit(1)
 	}
+}
 
+type JsonDestroyInfo struct {
+	Instance        string `json:"instance"`
+	Action          string `json:"action"`
+	Stopped         bool   `json:"stopped"`
+	ServiceRemoved  bool   `json:"serviceRemoved"`
+	BasePath        string `json:"basePath"`
+	Purged          bool   `json:"purged"`
+	MetadataRemoved bool   `json:"metadataRemoved"`
+	Status          string `json:"status"`
+	Warnings        string `json:"warnings"`
+	ErrorMessage    string `json:"errorMessage"`
+	Timestamp       string `json:"timestamp"`
+}
+
+type Option func(*JsonDestroyInfo)
+
+func NewJsonDestroyInfo(instance string, opts ...Option) *JsonDestroyInfo {
+	jsonDestroyInfo := &JsonDestroyInfo{
+		Instance:       instance,
+		Action:         "destroy",
+		ServiceRemoved: true,
+		Timestamp:      time.Now().Format(time.RFC3339),
+	}
+	for _, opt := range opts {
+		opt(jsonDestroyInfo)
+	}
+	return jsonDestroyInfo
+}
+
+func UpdateJsonDestroyInfo(jsonDestroyInfo *JsonDestroyInfo, opts ...Option) *JsonDestroyInfo {
+	for _, opt := range opts {
+		opt(jsonDestroyInfo)
+	}
+	return jsonDestroyInfo
+}
+
+func WithBasePath(basePath string) Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) { jsonDestroyInfo.BasePath = basePath }
+}
+
+func WithErrorMessage(errorMessage string) Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) {
+		jsonDestroyInfo.ErrorMessage = errorMessage
+		jsonDestroyInfo.Status = "error"
+	}
+}
+
+func WithStatus(status string) Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) { jsonDestroyInfo.Status = status }
+}
+
+func WithWarning(warning string) Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) { jsonDestroyInfo.Warnings = warning }
+}
+
+func WithServiceStopped() Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) {
+		jsonDestroyInfo.Stopped = true
+		jsonDestroyInfo.Status = "error"
+	}
+}
+
+func WithServiceRemoved() Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) {
+		jsonDestroyInfo.ServiceRemoved = true
+		jsonDestroyInfo.Status = "partial"
+	}
+}
+
+func WithPurged() Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) {
+		jsonDestroyInfo.Purged = true
+		jsonDestroyInfo.Status = "success"
+	}
+}
+
+func WithMetaDataRemoved() Option {
+	return func(jsonDestroyInfo *JsonDestroyInfo) {
+		jsonDestroyInfo.MetadataRemoved = true
+	}
+}
+
+func printDestroyJson(jsonDestroyInfo *JsonDestroyInfo) {
+	outputJSON, err := json.MarshalIndent(jsonDestroyInfo, "", "  ")
+	if err != nil {
+		fmt.Printf("Error generating JSON output: %v", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(outputJSON))
 }


### PR DESCRIPTION
Closes #129 

- A --json flag for structured, machine‑parsable output.
- --confirm-name <instance>: purge proceeds only if the value matches --instance exactly. If not provided (and --purge is set), the command prompts as today.
- --force: bypasses the name-typing prompt entirely when --purge is set. (Use sparingly; safer pipelines should prefer --confirm-name.)
- Precedence: if both are set, --force wins.
- If --purge and (--confirm-name matches or --force is present) → no prompt.
- Without --json, keep the existing console messages and flow.

---

## 🗂️ Scope of Change

- [ ] hydraidectl

> Optional: Select affected area(s) for better context

---

## 📓 Notes for Reviewers
Please let me know if there are further changes needed.
The solution might not work fully as expected:
 - Currently even with the `--json` flag we do see some logs from different part of the ctl tool, which should be handled as part of a different issue/ticket -> this could also be same for other commands and not just destroy. i.e., start, stop, restart.